### PR TITLE
Add tenant-aware venue filtering and broadcasts

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -4,7 +4,11 @@ class BookingsController < ApplicationController
 
   # GET /bookings or /bookings.json
   def index
-    @bookings = Booking.all
+    @bookings = if current_user.admin?
+                  Booking.includes(:venue, :user).order(start_time: :desc)
+                else
+                  Booking.for_tenant(current_user.tenant).includes(:venue, :user).order(start_time: :desc)
+                end
   end
 
   # GET /bookings/my
@@ -98,8 +102,7 @@ class BookingsController < ApplicationController
     def authorize_staff_for_booking
       return true if current_user.admin?
 
-      department = current_user_department
-      if department.present? && @booking.venue.department == department
+      if @booking.venue.accessible_by_tenant?(current_user.tenant)
         true
       else
         redirect_to approval_dashboard_path, alert: "You are not authorized to manage this booking."

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -8,11 +8,7 @@ class DashboardsController < ApplicationController
     @bookings = Booking.includes(:venue, :user).pending
 
     if current_user.staff?
-      if current_user_department.present?
-        @bookings = @bookings.joins(:venue).where(venues: { department: current_user_department })
-      else
-        @bookings = Booking.none
-      end
+      @bookings = @bookings.for_tenant(current_user.tenant)
     end
   end
 end

--- a/app/javascript/controllers/booking_status_controller.js
+++ b/app/javascript/controllers/booking_status_controller.js
@@ -5,6 +5,15 @@ export default class extends Controller {
     connect() {
         this.consumer = createConsumer()
         this.subscription = this.consumer.subscriptions.create("BookingStatusChannel", {
+            connected: () => {
+                this.element.dataset.bookingStatusConnection = "connected"
+            },
+            disconnected: () => {
+                this.element.dataset.bookingStatusConnection = "disconnected"
+            },
+            rejected: () => {
+                this.element.dataset.bookingStatusConnection = "rejected"
+            },
             received: (data) => {
                 this.updateStatus(data)
             }
@@ -21,11 +30,32 @@ export default class extends Controller {
     }
 
     updateStatus(data) {
+        if (!data || !data.booking_id) {
+            return
+        }
+
         const statusNode = this.element.querySelector(
             `[data-booking-id="${data.booking_id}"]`
         )
         if (statusNode) {
-            statusNode.textContent = data.status
+            const normalizedStatus = (data.status || "").toString().toLowerCase()
+            const label = data.status_label || this.humanizeStatus(normalizedStatus)
+
+            statusNode.textContent = label
+            if (normalizedStatus) {
+                statusNode.dataset.status = normalizedStatus
+            }
         }
+    }
+
+    humanizeStatus(status) {
+        if (!status) {
+            return "Unknown"
+        }
+
+        return status
+            .split("_")
+            .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+            .join(" ")
     }
 }

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -6,6 +6,8 @@ class Booking < ApplicationRecord
 
   enum :status, { pending: 0, approved: 1, rejected: 2 }
 
+  scope :for_tenant, ->(tenant) { joins(:venue).merge(Venue.visible_to_tenant(tenant)) }
+
   after_update_commit :broadcast_status_change, if: :saved_change_to_status?
 
   def approve!
@@ -21,7 +23,7 @@ class Booking < ApplicationRecord
   def broadcast_status_change
     ActionCable.server.broadcast(
       "booking_status_user_#{user_id}",
-      { booking_id: id, status: status.titleize }
+      { booking_id: id, status: status, status_label: status.titleize }
     )
   end
 end

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -1,4 +1,18 @@
 class Venue < ApplicationRecord
+  belongs_to :tenant, optional: true
+
   has_many :bookings, dependent: :destroy
   validates :name, :department, presence: true
+
+  scope :visible_to_tenant, lambda { |tenant|
+    return none unless tenant
+
+    where(tenant_id: tenant.id).or(where(tenant_id: nil, department: tenant.name))
+  }
+
+  def accessible_by_tenant?(tenant)
+    return false unless tenant
+
+    tenant_id.present? ? tenant_id == tenant.id : department == tenant.name
+  end
 end

--- a/app/views/bookings/my.html.erb
+++ b/app/views/bookings/my.html.erb
@@ -21,7 +21,7 @@
             <td><%= booking.start_time.to_date %></td>
             <td><%= booking.start_time.strftime("%H:%M") %></td>
             <td><%= booking.end_time.strftime("%H:%M") %></td>
-            <td data-booking-id="<%= booking.id %>"><%= booking.status.titleize %></td>
+            <td data-booking-id="<%= booking.id %>" data-status="<%= booking.status %>"><%= booking.status.titleize %></td>
           </tr>
         <% end %>
       </tbody>

--- a/db/migrate/20260325093000_add_tenant_to_venues.rb
+++ b/db/migrate/20260325093000_add_tenant_to_venues.rb
@@ -1,0 +1,16 @@
+class AddTenantToVenues < ActiveRecord::Migration[8.1]
+  def up
+    add_reference :venues, :tenant, foreign_key: true
+
+    execute <<~SQL.squish
+      UPDATE venues
+      SET tenant_id = tenants.id
+      FROM tenants
+      WHERE venues.department = tenants.name
+    SQL
+  end
+
+  def down
+    remove_reference :venues, :tenant, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_20_090100) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_25_093000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -61,11 +61,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_20_090100) do
     t.string "department"
     t.text "description"
     t.string "name"
+    t.bigint "tenant_id"
     t.datetime "updated_at", null: false
+    t.index ["tenant_id"], name: "index_venues_on_tenant_id"
   end
 
   add_foreign_key "bookings", "users"
   add_foreign_key "bookings", "venues"
   add_foreign_key "users", "societies"
   add_foreign_key "users", "tenants"
+  add_foreign_key "venues", "tenants"
 end

--- a/features/step_definitions/approval_workflow_steps.rb
+++ b/features/step_definitions/approval_workflow_steps.rb
@@ -1,6 +1,7 @@
 Given("the following venues exist:") do |table|
   table.hashes.each do |hash|
-    create(:venue, name: hash["name"], department: hash["department"])
+    tenant = Tenant.find_by(name: hash["department"]) || create(:tenant, name: hash["department"])
+    create(:venue, name: hash["name"], department: hash["department"], tenant: tenant)
   end
 end
 
@@ -82,7 +83,8 @@ Then("{string} should receive a rejection email with {string}") do |email, reaso
 end
 
 Given("there is a pending booking for {string} which belongs to {string}") do |venue_name, department|
-  venue = create(:venue, name: venue_name, department: department)
+  tenant = Tenant.find_by(name: department) || create(:tenant, name: department)
+  venue = create(:venue, name: venue_name, department: department, tenant: tenant)
   user = User.find_by(role: :society_member) || create(:user)
   create(:booking, venue: venue, user: user, status: :pending)
 end

--- a/spec/factories/venues.rb
+++ b/spec/factories/venues.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     sequence(:name) { |n| "Venue #{n}" }
     description { "MyText" }
     department { "Science Faculty" }
+
+    trait :with_tenant do
+      association :tenant, name: department
+    end
   end
 end

--- a/spec/models/booking_spec.rb
+++ b/spec/models/booking_spec.rb
@@ -31,4 +31,27 @@ RSpec.describe Booking, type: :model do
       expect(association.macro).to eq(:belongs_to)
     end
   end
+
+  describe '.for_tenant' do
+    let(:science_tenant) { create(:tenant, name: 'Science Faculty') }
+    let(:arts_tenant) { create(:tenant, name: 'Arts Faculty') }
+    let(:science_user) { create(:user, tenant: science_tenant) }
+    let(:arts_user) { create(:user, tenant: arts_tenant) }
+
+    it 'includes bookings on venues linked to the same tenant' do
+      scoped_venue = create(:venue, department: science_tenant.name, tenant: science_tenant)
+      other_venue = create(:venue, department: arts_tenant.name, tenant: arts_tenant)
+      included_booking = create(:booking, venue: scoped_venue, user: science_user)
+      create(:booking, venue: other_venue, user: arts_user)
+
+      expect(Booking.for_tenant(science_tenant)).to contain_exactly(included_booking)
+    end
+
+    it 'supports legacy venues without tenant_id using department name fallback' do
+      legacy_venue = create(:venue, department: science_tenant.name, tenant: nil)
+      booking = create(:booking, venue: legacy_venue, user: science_user)
+
+      expect(Booking.for_tenant(science_tenant)).to include(booking)
+    end
+  end
 end

--- a/spec/requests/bookings_spec.rb
+++ b/spec/requests/bookings_spec.rb
@@ -125,4 +125,66 @@ RSpec.describe "/bookings", type: :request do
       expect(response).to redirect_to(bookings_url)
     end
   end
+
+  describe "GET /approval_dashboard" do
+    let(:science_tenant) { create(:tenant, name: "Science Faculty") }
+    let(:arts_tenant) { create(:tenant, name: "Arts Faculty") }
+    let(:staff_user) { create(:user, :staff, tenant: science_tenant) }
+
+    before do
+      log_in_as(staff_user)
+    end
+
+    it "shows only pending bookings in the staff tenant" do
+      scoped_venue = create(:venue, name: "Room 101", department: science_tenant.name, tenant: science_tenant)
+      foreign_venue = create(:venue, name: "LT1", department: arts_tenant.name, tenant: arts_tenant)
+      create(:booking, venue: scoped_venue, user: user, status: :pending)
+      create(:booking, venue: foreign_venue, user: user, status: :pending)
+
+      get approval_dashboard_path
+
+      expect(response).to be_successful
+      expect(response.body).to include("Room 101")
+      expect(response.body).not_to include("LT1")
+    end
+
+    it "keeps legacy venues visible when department matches tenant name" do
+      legacy_venue = create(:venue, name: "Legacy Room", department: science_tenant.name, tenant: nil)
+      create(:booking, venue: legacy_venue, user: user, status: :pending)
+
+      get approval_dashboard_path
+
+      expect(response.body).to include("Legacy Room")
+    end
+  end
+
+  describe "PATCH /bookings/:id/approve" do
+    let(:science_tenant) { create(:tenant, name: "Science Faculty") }
+    let(:arts_tenant) { create(:tenant, name: "Arts Faculty") }
+    let(:staff_user) { create(:user, :staff, tenant: science_tenant) }
+
+    before do
+      log_in_as(staff_user)
+    end
+
+    it "allows staff to approve a booking in their tenant" do
+      scoped_venue = create(:venue, department: science_tenant.name, tenant: science_tenant)
+      booking = create(:booking, venue: scoped_venue, user: user, status: :pending)
+
+      patch approve_booking_path(booking)
+
+      expect(response).to redirect_to(approval_dashboard_path)
+      expect(booking.reload.status).to eq("approved")
+    end
+
+    it "rejects approval for bookings outside staff tenant" do
+      foreign_venue = create(:venue, department: arts_tenant.name, tenant: arts_tenant)
+      booking = create(:booking, venue: foreign_venue, user: user, status: :pending)
+
+      patch approve_booking_path(booking)
+
+      expect(response).to redirect_to(approval_dashboard_path)
+      expect(booking.reload.status).to eq("pending")
+    end
+  end
 end


### PR DESCRIPTION
Introduce tenant support for venues and scope bookings by tenant. Add a migration to reference tenants from venues and update schema/indexes. Venue model: optional belongs_to :tenant, visible_to_tenant scope and accessible_by_tenant helper. Booking: for_tenant scope, broadcast now includes raw status and a human-friendly status_label. Controllers: BookingsController and DashboardsController filter bookings by tenant for non-admin/staff and use tenant-based authorization. View: include data-status on booking rows. JS: connection lifecycle hooks, defensive checks, status normalization and humanization, and use status_label when provided. Tests and feature steps updated to create tenants and link venues; new specs cover tenant-scoped bookings and approval behavior.