### PR TITLE
Add tenant scoping and venue access control

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -4,11 +4,7 @@ class BookingsController < ApplicationController
 
   # GET /bookings or /bookings.json
   def index
-    @bookings = if current_user.admin?
-                  Booking.includes(:venue, :user).order(start_time: :desc)
-    else
-                  Booking.for_tenant(current_user.tenant).includes(:venue, :user).order(start_time: :desc)
-    end
+    @bookings = booking_scope.order(start_time: :desc)
   end
 
   # GET /bookings/my
@@ -23,17 +19,28 @@ class BookingsController < ApplicationController
   # GET /bookings/new
   def new
     @booking = Booking.new
-    @booking.venue_id = params[:venue_id] if params[:venue_id]
+    @venues = accessible_venues.order(:name)
+    if params[:venue_id].present? && venue_accessible?(params[:venue_id])
+      @booking.venue_id = params[:venue_id]
+    end
   end
 
   # GET /bookings/1/edit
   def edit
+    @venues = accessible_venues.order(:name)
   end
 
   # POST /bookings or /bookings.json
   def create
     @booking = Booking.new(booking_params)
     @booking.user = current_user
+    @venues = accessible_venues.order(:name)
+
+    unless venue_accessible?(@booking.venue_id)
+      @booking.errors.add(:venue, "is not accessible for your account")
+      render :new, status: :unprocessable_entity
+      return
+    end
 
     respond_to do |format|
       if @booking.save
@@ -48,6 +55,14 @@ class BookingsController < ApplicationController
 
   # PATCH/PUT /bookings/1 or /bookings/1.json
   def update
+    @venues = accessible_venues.order(:name)
+    requested_venue_id = booking_params[:venue_id].presence || @booking.venue_id
+    unless venue_accessible?(requested_venue_id)
+      @booking.errors.add(:venue, "is not accessible for your account")
+      render :edit, status: :unprocessable_entity
+      return
+    end
+
     respond_to do |format|
       if @booking.update(booking_params)
         format.html { redirect_to @booking, notice: "Booking was successfully updated.", status: :see_other }
@@ -60,8 +75,6 @@ class BookingsController < ApplicationController
   end
 
   def approve
-    return unless authorize_staff_for_booking
-
     @booking.approve!
     BookingMailer.with(booking: @booking).approved.deliver_now
 
@@ -69,8 +82,6 @@ class BookingsController < ApplicationController
   end
 
   def reject
-    return unless authorize_staff_for_booking
-
     reason = params[:rejection_reason].to_s.strip
     @booking.reject!(reason)
     BookingMailer.with(booking: @booking, reason: reason).rejected.deliver_now
@@ -91,7 +102,9 @@ class BookingsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_booking
-      @booking = Booking.find(params.expect(:id))
+      @booking = booking_scope.find(params.expect(:id))
+    rescue ActiveRecord::RecordNotFound
+      redirect_to unauthorized_booking_redirect_path, alert: "You are not authorized to access this booking."
     end
 
     # Only allow a list of trusted parameters through.
@@ -99,14 +112,27 @@ class BookingsController < ApplicationController
       params.require(:booking).permit(:venue_id, :start_time, :end_time)
     end
 
-    def authorize_staff_for_booking
-      return true if current_user.admin?
-
-      if @booking.venue.accessible_by_tenant?(current_user.tenant)
-        true
+    def booking_scope
+      if current_user.admin?
+        Booking.includes(:venue, :user)
+      elsif current_user.staff?
+        Booking.for_tenant(current_user.tenant).includes(:venue, :user)
       else
-        redirect_to approval_dashboard_path, alert: "You are not authorized to manage this booking."
-        false
+        current_user.bookings.includes(:venue, :user)
       end
+    end
+
+    def accessible_venues
+      Venue.visible_to_user(current_user)
+    end
+
+    def venue_accessible?(venue_id)
+      accessible_venues.exists?(id: venue_id)
+    end
+
+    def unauthorized_booking_redirect_path
+      return approval_dashboard_path if action_name.in?(["approve", "reject"])
+
+      current_user.admin? || current_user.staff? ? bookings_path : my_bookings_path
     end
 end

--- a/app/controllers/venues_controller.rb
+++ b/app/controllers/venues_controller.rb
@@ -4,7 +4,7 @@ class VenuesController < ApplicationController
 
   # GET /venues or /venues.json
   def index
-    @venues = Venue.all
+    @venues = accessible_venues.order(:name)
   end
 
   # GET /venues/1 or /venues/1.json
@@ -23,6 +23,7 @@ class VenuesController < ApplicationController
   # POST /venues or /venues.json
   def create
     @venue = Venue.new(venue_params)
+    apply_staff_tenant_defaults
 
     respond_to do |format|
       if @venue.save
@@ -37,6 +38,8 @@ class VenuesController < ApplicationController
 
   # PATCH/PUT /venues/1 or /venues/1.json
   def update
+    apply_staff_tenant_defaults
+
     respond_to do |format|
       if @venue.update(venue_params)
         format.html { redirect_to @venue, notice: "Venue was successfully updated.", status: :see_other }
@@ -61,11 +64,28 @@ class VenuesController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_venue
-      @venue = Venue.find(params.expect(:id))
+      @venue = accessible_venues.find(params.expect(:id))
+    rescue ActiveRecord::RecordNotFound
+      redirect_to venues_path, alert: "You are not authorized to access this venue."
     end
 
     # Only allow a list of trusted parameters through.
     def venue_params
-      params.expect(venue: [:name, :description, :department])
+      permitted = [:name, :description]
+      if current_user.admin?
+        permitted += [:department, :tenant_id]
+      end
+      params.expect(venue: permitted)
+    end
+
+    def accessible_venues
+      Venue.visible_to_user(current_user)
+    end
+
+    def apply_staff_tenant_defaults
+      return if current_user.admin?
+
+      @venue.tenant = current_user.tenant
+      @venue.department = current_user.tenant&.name
     end
 end

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -4,15 +4,39 @@ class Venue < ApplicationRecord
   has_many :bookings, dependent: :destroy
   validates :name, :department, presence: true
 
+  scope :visible_to_user, lambda { |user|
+    return none unless user
+    return all if user.admin?
+
+    if user.tenant
+      visible_to_tenant(user.tenant)
+    else
+      where(tenant_id: nil)
+    end
+  }
+
   scope :visible_to_tenant, lambda { |tenant|
     return none unless tenant
 
-    where(tenant_id: tenant.id).or(where(tenant_id: nil, department: tenant.name))
+    scoped = where(tenant_id: tenant.id)
+    if legacy_department_fallback_enabled?
+      scoped.or(where(tenant_id: nil, department: tenant.name))
+    else
+      scoped
+    end
   }
 
   def accessible_by_tenant?(tenant)
     return false unless tenant
 
-    tenant_id.present? ? tenant_id == tenant.id : department == tenant.name
+    return tenant_id == tenant.id if tenant_id.present?
+
+    self.class.legacy_department_fallback_enabled? && department == tenant.name
+  end
+
+  def self.legacy_department_fallback_enabled?
+    ActiveModel::Type::Boolean.new.cast(
+      ENV.fetch("ALLOW_LEGACY_TENANT_DEPARTMENT_FALLBACK", "true")
+    )
   end
 end

--- a/app/views/bookings/_form.html.erb
+++ b/app/views/bookings/_form.html.erb
@@ -17,7 +17,7 @@
   <% else %>
     <div>
       <%= form.label :venue_id, style: "display: block" %>
-      <%= form.collection_select :venue_id, Venue.all, :id, :name %>
+      <%= form.collection_select :venue_id, (@venues || Venue.none), :id, :name %>
     </div>
   <% end %>
 

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,7 +6,8 @@ development:
   adapter: async
 
 test:
-  adapter: test
+  # Use async in test to support end-to-end ActionCable behavior in JS features.
+  adapter: async
 
 production:
   adapter: solid_cable

--- a/features/approval_workflow.feature
+++ b/features/approval_workflow.feature
@@ -37,6 +37,13 @@ Feature: Booking Approval Workflow
     When I visit the approval dashboard
     Then I should not see the booking for "LT1"
 
+  Scenario: Staff cannot approve another department booking via direct request
+    Given I am logged in as "staff@link.cuhk.edu.hk"
+    And there is a pending booking for "LT1" which belongs to "Arts Faculty"
+    When I attempt to approve the booking for "LT1" on "2026-04-20" directly
+    Then the booking for "LT1" on "2026-04-20" should remain "Pending"
+    And I should see "You are not authorized to access this booking."
+
   Scenario: Society member cannot access approval dashboard
     Given I am logged in as "student@link.cuhk.edu.hk"
     When I visit the approval dashboard

--- a/features/step_definitions/approval_workflow_steps.rb
+++ b/features/step_definitions/approval_workflow_steps.rb
@@ -86,13 +86,42 @@ Given("there is a pending booking for {string} which belongs to {string}") do |v
   tenant = Tenant.find_by(name: department) || create(:tenant, name: department)
   venue = create(:venue, name: venue_name, department: department, tenant: tenant)
   user = User.find_by(role: :society_member) || create(:user)
-  create(:booking, venue: venue, user: user, status: :pending)
+  create(
+    :booking,
+    venue: venue,
+    user: user,
+    status: :pending,
+    start_time: Time.zone.parse("2026-04-20 10:00"),
+    end_time: Time.zone.parse("2026-04-20 12:00")
+  )
+end
+
+When("I attempt to approve the booking for {string} on {string} directly") do |venue_name, date|
+  booking = Booking.joins(:venue)
+                   .where(venues: { name: venue_name })
+                   .where(start_time: Time.zone.parse(date).all_day)
+                   .first
+
+  page.driver.submit :patch, approve_booking_path(booking), {}
+end
+
+Then("the booking for {string} on {string} should remain {string}") do |venue_name, date, status|
+  booking = Booking.joins(:venue)
+                   .where(venues: { name: venue_name })
+                   .where(start_time: Time.zone.parse(date).all_day)
+                   .first
+
+  expect(booking.reload.status).to eq(status.downcase)
 end
 
 Given("I am viewing {string}") do |page_name|
   case page_name
   when "My Bookings"
     visit my_bookings_path
+    expect(page).to have_css(
+      "[data-controller='booking-status'][data-booking-status-connection='connected']",
+      wait: 10
+    )
   else
     raise "Unknown page: #{page_name}"
   end
@@ -119,7 +148,7 @@ end
 
 Then("I should see the status update to {string} without refreshing the page") do |status|
   booking = @current_booking || Booking.last
-  expect(page).to have_css("[data-booking-id='#{booking.id}']", text: status)
+  expect(page).to have_css("[data-booking-id='#{booking.id}']", text: status, wait: 10)
 end
 
 Then("I should not be on the approval dashboard page") do

--- a/spec/models/booking_spec.rb
+++ b/spec/models/booking_spec.rb
@@ -54,4 +54,25 @@ RSpec.describe Booking, type: :model do
       expect(Booking.for_tenant(science_tenant)).to include(booking)
     end
   end
+
+  describe 'status broadcasts' do
+    it 'broadcasts status payload when status changes' do
+      booking = create(:booking, status: :pending)
+
+      expect(ActionCable.server).to receive(:broadcast).with(
+        "booking_status_user_#{booking.user_id}",
+        hash_including(booking_id: booking.id, status: 'approved', status_label: 'Approved')
+      )
+
+      booking.update!(status: :approved)
+    end
+
+    it 'does not broadcast when status is unchanged' do
+      booking = create(:booking, status: :pending)
+
+      expect(ActionCable.server).not_to receive(:broadcast)
+
+      booking.update!(end_time: booking.end_time + 30.minutes)
+    end
+  end
 end

--- a/spec/requests/bookings_spec.rb
+++ b/spec/requests/bookings_spec.rb
@@ -187,4 +187,67 @@ RSpec.describe "/bookings", type: :request do
       expect(booking.reload.status).to eq("pending")
     end
   end
+
+  describe "PATCH /bookings/:id/reject" do
+    let(:science_tenant) { create(:tenant, name: "Science Faculty") }
+    let(:arts_tenant) { create(:tenant, name: "Arts Faculty") }
+    let(:staff_user) { create(:user, :staff, tenant: science_tenant) }
+
+    before do
+      log_in_as(staff_user)
+    end
+
+    it "allows staff to reject a booking in their tenant and saves reason" do
+      scoped_venue = create(:venue, department: science_tenant.name, tenant: science_tenant)
+      booking = create(:booking, venue: scoped_venue, user: user, status: :pending)
+
+      patch reject_booking_path(booking), params: { rejection_reason: "Maintenance" }
+
+      expect(response).to redirect_to(approval_dashboard_path)
+      expect(booking.reload.status).to eq("rejected")
+      expect(booking.rejection_reason).to eq("Maintenance")
+    end
+
+    it "blocks staff from rejecting bookings outside their tenant" do
+      foreign_venue = create(:venue, department: arts_tenant.name, tenant: arts_tenant)
+      booking = create(:booking, venue: foreign_venue, user: user, status: :pending)
+
+      patch reject_booking_path(booking), params: { rejection_reason: "Not allowed" }
+
+      expect(response).to redirect_to(approval_dashboard_path)
+      expect(flash[:alert]).to eq("You are not authorized to access this booking.")
+      expect(booking.reload.status).to eq("pending")
+      expect(booking.rejection_reason).to be_nil
+    end
+  end
+
+  describe "tenant and ownership hardening" do
+    let(:science_tenant) { create(:tenant, name: "Science Faculty") }
+    let(:arts_tenant) { create(:tenant, name: "Arts Faculty") }
+
+    it "prevents society members from viewing bookings owned by another user" do
+      owner = create(:user, tenant: science_tenant)
+      intruder = create(:user, tenant: science_tenant)
+      booking = create(:booking, user: owner, venue: create(:venue, tenant: science_tenant, department: science_tenant.name))
+
+      log_in_as(intruder)
+      get booking_url(booking)
+
+      expect(response).to redirect_to(my_bookings_path)
+      expect(flash[:alert]).to eq("You are not authorized to access this booking.")
+    end
+
+    it "prevents users from assigning bookings to venues outside their tenant" do
+      member = create(:user, tenant: science_tenant)
+      own_venue = create(:venue, tenant: science_tenant, department: science_tenant.name)
+      foreign_venue = create(:venue, tenant: arts_tenant, department: arts_tenant.name)
+      booking = create(:booking, user: member, venue: own_venue)
+
+      log_in_as(member)
+      patch booking_url(booking), params: { booking: { venue_id: foreign_venue.id } }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(booking.reload.venue_id).to eq(own_venue.id)
+    end
+  end
 end

--- a/spec/requests/venues_spec.rb
+++ b/spec/requests/venues_spec.rb
@@ -2,12 +2,15 @@ require 'rails_helper'
 
 RSpec.describe "/venues", type: :request do
   let(:valid_attributes) {
-    { name: "Lecture Sol 1", description: "Large hall for 200 people" }
+    { name: "Lecture Sol 1", description: "Large hall for 200 people", department: "Science Faculty" }
   }
 
   let(:invalid_attributes) {
     { name: nil }
   }
+
+  let(:science_tenant) { create(:tenant, name: "Science Faculty") }
+  let(:arts_tenant) { create(:tenant, name: "Arts Faculty") }
 
   let(:admin) { FactoryBot.create(:user, :admin) }
 
@@ -21,6 +24,19 @@ RSpec.describe "/venues", type: :request do
       get venues_url
       expect(response).to be_successful
     end
+
+    it "scopes staff to venues in their tenant" do
+      staff = create(:user, :staff, tenant: science_tenant)
+      visible_venue = create(:venue, name: "Room 101", tenant: science_tenant, department: science_tenant.name)
+      hidden_venue = create(:venue, name: "LT1", tenant: arts_tenant, department: arts_tenant.name)
+
+      log_in_as(staff)
+      get venues_url
+
+      expect(response).to be_successful
+      expect(response.body).to include(visible_venue.name)
+      expect(response.body).not_to include(hidden_venue.name)
+    end
   end
 
   describe "GET /show" do
@@ -28,6 +44,17 @@ RSpec.describe "/venues", type: :request do
       venue = Venue.create! valid_attributes
       get venue_url(venue)
       expect(response).to be_successful
+    end
+
+    it "prevents staff from opening venues in another tenant" do
+      staff = create(:user, :staff, tenant: science_tenant)
+      foreign_venue = create(:venue, tenant: arts_tenant, department: arts_tenant.name)
+
+      log_in_as(staff)
+      get venue_url(foreign_venue)
+
+      expect(response).to redirect_to(venues_path)
+      expect(flash[:alert]).to eq("You are not authorized to access this venue.")
     end
   end
 

--- a/spec/views/bookings/new.html.erb_spec.rb
+++ b/spec/views/bookings/new.html.erb_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "bookings/new", type: :view do
   before(:each) do
+    assign(:venues, [create(:venue, name: "Room 101", department: "Science Faculty")])
     assign(:booking, Booking.new(
       venue: nil,
       user: nil

--- a/spec/views/venues/edit.html.erb_spec.rb
+++ b/spec/views/venues/edit.html.erb_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe "venues/edit", type: :view do
   let(:venue) {
     Venue.create!(
       name: "MyString",
-      description: "MyText"
+      description: "MyText",
+      department: "Science Faculty"
     )
   }
 

--- a/spec/views/venues/index.html.erb_spec.rb
+++ b/spec/views/venues/index.html.erb_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe "venues/index", type: :view do
     assign(:venues, [
       Venue.create!(
         name: "Venue 1",
-        description: "Desc 1"
+        description: "Desc 1",
+        department: "Science Faculty"
       ),
       Venue.create!(
         name: "Venue 2",
-        description: "Desc 2"
+        description: "Desc 2",
+        department: "Science Faculty"
       )
     ])
   end

--- a/spec/views/venues/show.html.erb_spec.rb
+++ b/spec/views/venues/show.html.erb_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe "venues/show", type: :view do
     def view.current_user; nil; end
     assign(:venue, Venue.create!(
       name: "Name",
-      description: "MyText"
+      description: "MyText",
+      department: "Science Faculty"
     ))
   end
 


### PR DESCRIPTION
Introduce tenant-aware scoping and authorization for venues and bookings. Refactor BookingsController to use booking_scope, enforce accessible_venues for new/create/update, guard direct approve/reject access, and handle unauthorized record access with redirects. VenuesController now scopes index to accessible_venues, limits permitted params for non-admins, and applies staff tenant/department defaults on create/update. Venue model gains visible_to_user/visible_to_tenant scopes, legacy department fallback behind ENV flag, and accessible_by_tenant logic adjusted. Update booking form to use @venues, change test ActionCable adapter to async, add feature/step for direct-approve protection, and add/request/ view specs covering broadcasts, rejection handling, tenant/ownership hardening, and view fixtures including department attributes.