### PR TITLE
feat: configure CI/CD deployment to Azure VM

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -1,0 +1,186 @@
+name: CD - Azure VM
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types: [completed]
+
+env:
+  APP_ROOT: /opt/cuhk-booking-system
+  RELEASE_ARCHIVE: /tmp/cuhk-booking-system-release.tgz
+  REMOTE_ENV_FILE: /tmp/cuhk-booking-system.env.production
+  AZURE_VM_USER: azureuser
+  APP_HOST: csci3100.tylerl.cyou
+  POSTGRES_HOST: db
+  POSTGRES_PORT: 5432
+  POSTGRES_USER: postgres
+  POSTGRES_DB: cuhk_booking_system_production
+  POSTGRES_CACHE_DB: cuhk_booking_system_production_cache
+  POSTGRES_QUEUE_DB: cuhk_booking_system_production_queue
+  POSTGRES_CABLE_DB: cuhk_booking_system_production_cable
+
+concurrency:
+  group: deploy-azure-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Configure SSH
+        env:
+          AZURE_VM_HOST: ${{ secrets.AZURE_VM_HOST }}
+          AZURE_VM_SSH_KEY: ${{ secrets.AZURE_VM_SSH_KEY }}
+        run: |
+          : "${AZURE_VM_HOST:?Set AZURE_VM_HOST in repository secrets.}"
+          : "${AZURE_VM_SSH_KEY:?Set AZURE_VM_SSH_KEY in repository secrets.}"
+
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$AZURE_VM_SSH_KEY" > ~/.ssh/azure.pem
+          chmod 600 ~/.ssh/azure.pem
+          ssh-keyscan -H "$AZURE_VM_HOST" >> ~/.ssh/known_hosts
+
+      - name: Create release archive
+        run: |
+          tar \
+            --exclude=.git \
+            --exclude=log \
+            --exclude=tmp \
+            --exclude=coverage \
+            --exclude=node_modules \
+            -czf "$RELEASE_ARCHIVE" .
+
+      - name: Create production environment file
+        env:
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+        run: |
+          : "${RAILS_MASTER_KEY:?Set RAILS_MASTER_KEY in repository secrets.}"
+          : "${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in repository secrets.}"
+
+          {
+            printf '%s\n' "RAILS_ENV=production"
+            printf '%s\n' "RAILS_LOG_TO_STDOUT=true"
+            printf '%s\n' "SOLID_QUEUE_IN_PUMA=true"
+            printf '%s\n' "APP_HOST=$APP_HOST"
+            printf '%s\n' "RAILS_MASTER_KEY=$RAILS_MASTER_KEY"
+            printf '%s\n' "SECRET_KEY_BASE=$SECRET_KEY_BASE"
+            printf '%s\n' "POSTGRES_HOST=$POSTGRES_HOST"
+            printf '%s\n' "POSTGRES_PORT=$POSTGRES_PORT"
+            printf '%s\n' "POSTGRES_USER=$POSTGRES_USER"
+            printf '%s\n' "POSTGRES_PASSWORD=$POSTGRES_PASSWORD"
+            printf '%s\n' "POSTGRES_DB=$POSTGRES_DB"
+            printf '%s\n' "POSTGRES_CACHE_DB=$POSTGRES_CACHE_DB"
+            printf '%s\n' "POSTGRES_QUEUE_DB=$POSTGRES_QUEUE_DB"
+            printf '%s\n' "POSTGRES_CABLE_DB=$POSTGRES_CABLE_DB"
+          } > "$REMOTE_ENV_FILE"
+
+          chmod 600 "$REMOTE_ENV_FILE"
+
+      - name: Upload release assets
+        env:
+          AZURE_VM_HOST: ${{ secrets.AZURE_VM_HOST }}
+        run: |
+          scp -i ~/.ssh/azure.pem "$RELEASE_ARCHIVE" "$REMOTE_ENV_FILE" "$AZURE_VM_USER@$AZURE_VM_HOST:/tmp/"
+
+      - name: Deploy release on VM
+        env:
+          AZURE_VM_HOST: ${{ secrets.AZURE_VM_HOST }}
+          DEPLOY_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          ssh -i ~/.ssh/azure.pem "$AZURE_VM_USER@$AZURE_VM_HOST" \
+            "APP_ROOT='$APP_ROOT' RELEASE_ARCHIVE='$RELEASE_ARCHIVE' REMOTE_ENV_FILE='$REMOTE_ENV_FILE' DEPLOY_SHA='$DEPLOY_SHA' bash -s" <<'REMOTE'
+          set -euo pipefail
+
+          releases_dir="$APP_ROOT/releases"
+          shared_dir="$APP_ROOT/shared"
+          release_dir="$releases_dir/$DEPLOY_SHA"
+          current_link="$APP_ROOT/current"
+          previous_release=""
+
+          if [ -L "$current_link" ]; then
+            previous_release="$(readlink -f "$current_link")"
+          fi
+
+          if ! command -v docker >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install --no-install-recommends -y docker.io curl ca-certificates
+          fi
+
+          if ! sudo docker compose version >/dev/null 2>&1 && ! command -v docker-compose >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install --no-install-recommends -y docker-compose-plugin || sudo apt-get install --no-install-recommends -y docker-compose
+          fi
+          sudo systemctl enable --now docker
+
+          sudo mkdir -p "$releases_dir" "$shared_dir"
+          sudo chown -R "$USER:$USER" "$APP_ROOT"
+
+          mkdir -p "$release_dir"
+          tar -xzf "$RELEASE_ARCHIVE" -C "$release_dir"
+          install -m 600 "$REMOTE_ENV_FILE" "$shared_dir/.env.production"
+
+          compose_cmd=(sudo docker compose)
+          if ! sudo docker compose version >/dev/null 2>&1; then
+            compose_cmd=(sudo docker-compose)
+          fi
+
+          deploy_release() {
+            local target_dir="$1"
+            cd "$target_dir"
+            "${compose_cmd[@]}" \
+              --project-name cuhk-booking \
+              -f deploy/docker-compose.azure.yml \
+              --env-file "$shared_dir/.env.production" \
+              up -d --build --remove-orphans
+          }
+
+          rollback() {
+            if [ -n "$previous_release" ] && [ -d "$previous_release" ]; then
+              ln -sfn "$previous_release" "$current_link"
+              deploy_release "$previous_release"
+            fi
+          }
+
+          ln -sfn "$release_dir" "$current_link"
+
+          if ! deploy_release "$release_dir"; then
+            rollback
+            exit 1
+          fi
+
+          healthy=0
+          for _ in $(seq 1 20); do
+            if curl --fail --silent --show-error http://127.0.0.1:3000/up >/dev/null; then
+              healthy=1
+              break
+            fi
+            sleep 3
+          done
+
+          if [ "$healthy" -ne 1 ]; then
+            rollback
+            exit 1
+          fi
+
+          find "$releases_dir" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' \
+            | sort -rn \
+            | awk 'NR > 5 { print $2 }' \
+            | xargs -r rm -rf
+          rm -f "$RELEASE_ARCHIVE" "$REMOTE_ENV_FILE"
+          REMOTE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # check=error=true
 
-# This Dockerfile is designed for production, not development. Use with Kamal or build'n'run by hand:
+# This Dockerfile is designed for production, not development. Use with docker compose or build'n'run by hand:
 # docker build -t store .
 # docker run -d -p 80:80 -e RAILS_MASTER_KEY=<value from config/master.key> --name store store
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,7 @@ GEM
     ffi (1.17.3-aarch64-linux-musl)
     ffi (1.17.3-arm-linux-gnu)
     ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
     ffi (1.17.3-x64-mingw-ucrt)
     ffi (1.17.3-x86_64-linux-gnu)
     ffi (1.17.3-x86_64-linux-musl)
@@ -242,6 +243,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.2-arm-linux-musl)
       racc (~> 1.4)
+    nokogiri (1.19.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.19.2-x64-mingw-ucrt)
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-gnu)
@@ -256,6 +259,7 @@ GEM
     pg (1.6.3)
     pg (1.6.3-aarch64-linux)
     pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-arm64-darwin)
     pg (1.6.3-x64-mingw-ucrt)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
@@ -429,6 +433,7 @@ GEM
     thor (1.5.0)
     thruster (0.1.20)
     thruster (0.1.20-aarch64-linux)
+    thruster (0.1.20-arm64-darwin)
     thruster (0.1.20-x86_64-linux)
     timeout (0.6.1)
     tsort (0.2.0)
@@ -464,6 +469,7 @@ PLATFORMS
   aarch64-linux-musl
   arm-linux-gnu
   arm-linux-musl
+  arm64-darwin-25
   x64-mingw-ucrt
   x86_64-linux
   x86_64-linux-gnu

--- a/README.md
+++ b/README.md
@@ -86,8 +86,45 @@ If you ran `rails db:seed`, the development database includes the following acco
 | **Staff** | `staff@cuhk.edu.hk` | `Password1!` |
 | **Society Member** | `member@cuhk.edu.hk` | `Password1!` |
 
-## Deployment
+## Deployment (Azure VM)
 
-Deployed with heroku:
-[https://cuhk-booking-system-33bfcf694971.herokuapp.com/](https://cuhk-booking-system-33bfcf694971.herokuapp.com/)
+Production URL: [https://csci3100.tylerl.cyou](https://csci3100.tylerl.cyou)
 
+CI remains in `.github/workflows/ci.yml`, and CD is configured in `.github/workflows/deploy-azure.yml`.
+The deploy workflow runs automatically after `CI` succeeds on `main`, and can also be triggered manually from GitHub Actions.
+
+### 1. One-time Azure VM preparation
+
+Connect with your key:
+```bash
+ssh -i azure.pem azureuser@<azure-vm-public-ip-or-dns>
+```
+
+Ensure Caddy is configured to proxy to the app:
+```caddy
+csci3100.tylerl.cyou {
+    reverse_proxy 127.0.0.1:3000
+}
+```
+
+If needed, reload Caddy:
+```bash
+sudo caddy validate --config /etc/caddy/Caddyfile
+sudo systemctl reload caddy
+```
+
+### 2. Add required GitHub repository secrets
+
+| Secret | Value |
+| --- | --- |
+| `AZURE_VM_HOST` | Azure VM public IP or DNS name |
+| `AZURE_VM_SSH_KEY` | Full private key content from `azure.pem` |
+| `RAILS_MASTER_KEY` | Content of `config/master.key` |
+| `POSTGRES_PASSWORD` | Password for the production Postgres container |
+| `SECRET_KEY_BASE` | Optional but recommended (`openssl rand -hex 64`) |
+
+### 3. Deploy
+
+1. Merge/push to `main` (deploy runs after CI passes), or run **CD - Azure VM** manually in GitHub Actions.
+2. The workflow uploads the repository to `/opt/cuhk-booking-system`, builds containers on the VM, and starts them with `deploy/docker-compose.azure.yml`.
+3. It keeps recent releases and rolls back to the previous release automatically if health checks fail.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST", "csci3100.tylerl.cyou") }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via bin/rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/deploy/docker-compose.azure.yml
+++ b/deploy/docker-compose.azure.yml
@@ -1,0 +1,52 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      RAILS_ENV: production
+      RAILS_LOG_TO_STDOUT: "true"
+      SOLID_QUEUE_IN_PUMA: ${SOLID_QUEUE_IN_PUMA:-true}
+      APP_HOST: ${APP_HOST}
+      RAILS_MASTER_KEY: ${RAILS_MASTER_KEY}
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_CACHE_DB: ${POSTGRES_CACHE_DB}
+      POSTGRES_QUEUE_DB: ${POSTGRES_QUEUE_DB}
+      POSTGRES_CABLE_DB: ${POSTGRES_CABLE_DB}
+    ports:
+      - "127.0.0.1:3000:80"
+    volumes:
+      - rails_storage:/rails/storage
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1/up || exit 1"]
+      interval: 20s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  rails_storage:


### PR DESCRIPTION
## Summary
This PR replaces the old deployment approach with an automated GitHub Actions CD pipeline for our Azure VM and updates deployment docs for the new production setup.

## What changed
- Added **CD workflow**: `.github/workflows/deploy-azure.yml`
  - Triggers after CI succeeds on `main` (and supports manual `workflow_dispatch`)
  - Connects to the VM over SSH using `azureuser` + repository secrets
  - Uploads a release archive, deploys with Docker Compose, runs health checks, and performs automatic rollback on failure
  - Keeps the latest releases and cleans up older ones
- Added **Azure production compose file**: `deploy/docker-compose.azure.yml`
  - Runs Rails + PostgreSQL containers
  - Binds Rails to `127.0.0.1:3000` for Caddy reverse proxy
- Updated **production host configuration**
  - `config/environments/production.rb` now uses `APP_HOST` (default: `csci3100.tylerl.cyou`) for generated URLs
- Updated **README deployment section**
  - Removed Heroku references
  - Documented Azure VM + Caddy setup and required GitHub secrets
- Updated Dockerfile comment to remove legacy Kamal wording

## Required GitHub repository secrets
- `AZURE_VM_HOST`
- `AZURE_VM_SSH_KEY` (content of `azure.pem`)
- `RAILS_MASTER_KEY`
- `POSTGRES_PASSWORD`
- `SECRET_KEY_BASE`

## Deployment target
- Domain: `https://csci3100.tylerl.cyou`
- Caddy reverse proxy: `csci3100.tylerl.cyou -> 127.0.0.1:3000`

## Impact
- Deployment is now automated for Azure VM
- Old Heroku deployment flow is deprecated
