### PR TITLE
fix: resolve Azure deploy Dockerfile path

### DIFF
--- a/deploy/docker-compose.azure.yml
+++ b/deploy/docker-compose.azure.yml
@@ -16,8 +16,8 @@ services:
 
   web:
     build:
-      context: .
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: ../Dockerfile
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
Fixes Azure deployment failure caused by Docker Compose build path resolution.

## Root cause
`deploy/docker-compose.azure.yml` is in `deploy/`, and Compose resolves relative build paths from that file location. The prior config used `context: .` and `dockerfile: Dockerfile`, which made Compose look for `deploy/Dockerfile` on the VM.

## Fix
- `build.context: ..`
- `build.dockerfile: ../Dockerfile`

## Result
CD can now locate the real Dockerfile at repo root and continue deployment to the Azure VM.
