### PR TITLE
fix: add Rails /up health endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "up" => "rails/health#show", as: :rails_health_check
+
   get  "login",  to: "sessions#new"
   post "login",  to: "sessions#create"
   delete "logout", to: "sessions#destroy"


### PR DESCRIPTION
## Summary
Adds an explicit Rails health route for deployment probes.

## Why
Azure CD checks `http://127.0.0.1:3000/up`, but the app had no `/up` route, causing repeated `404` and failed deploy rollback.

## Change
- Added route in `config/routes.rb`:
  - `get "up" => "rails/health#show", as: :rails_health_check`

## Result
Deployment health checks align with workflow/compose probes and can pass once the app is up.
