### PR TITLE
Harden booking lifecycle transitions

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -121,6 +121,8 @@ class BookingsController < ApplicationController
     BookingMailer.with(booking: @booking).approved.deliver_now
 
     redirect_to approval_dashboard_path, notice: "Booking approved."
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to approval_dashboard_path, alert: booking_transition_error_message(e, "Booking could not be approved.")
   end
 
   def reject
@@ -129,11 +131,15 @@ class BookingsController < ApplicationController
     BookingMailer.with(booking: @booking, reason: reason).rejected.deliver_now
 
     redirect_to approval_dashboard_path, notice: "Booking rejected."
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to approval_dashboard_path, alert: booking_transition_error_message(e, "Booking could not be rejected.")
   end
 
   def mark_returned
-    @booking.update!(status: :returned)
+    @booking.mark_returned!
     redirect_to my_bookings_path, notice: "Equipment returned successfully."
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to my_bookings_path, alert: booking_transition_error_message(e, "Booking could not be marked as returned.")
   end
 
   # DELETE /bookings/1 or /bookings/1.json
@@ -307,5 +313,9 @@ class BookingsController < ApplicationController
       end
 
       options
+    end
+
+    def booking_transition_error_message(error, fallback_message)
+      error.record.errors.full_messages.to_sentence.presence || fallback_message
     end
 end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,4 +1,8 @@
 class Booking < ApplicationRecord
+  APPROVABLE_FROM_STATUSES = %w[pending].freeze
+  REJECTABLE_FROM_STATUSES = %w[pending].freeze
+  RETURNABLE_EQUIPMENT_STATUSES = %w[approved borrowed].freeze
+
   belongs_to :user
   belongs_to :equipment, optional: true
   belongs_to :venue, optional: true
@@ -13,11 +17,35 @@ class Booking < ApplicationRecord
   scope :for_tenant, ->(tenant) { BookingScopeQuery.for_tenant(tenant) }
 
   def approve!
-    update!(status: :approved, rejection_reason: nil)
+    transition_status!(
+      target_status: :approved,
+      allowed_from: APPROVABLE_FROM_STATUSES,
+      extra_attributes: { rejection_reason: nil }
+    )
   end
 
   def reject!(reason)
-    update!(status: :rejected, rejection_reason: reason)
+    transition_status!(
+      target_status: :rejected,
+      allowed_from: REJECTABLE_FROM_STATUSES,
+      extra_attributes: { rejection_reason: reason }
+    )
+  end
+
+  def mark_returned!
+    unless equipment.present?
+      errors.add(:status, "can only be marked as returned for equipment bookings")
+      raise ActiveRecord::RecordInvalid, self
+    end
+
+    transition_status!(
+      target_status: :returned,
+      allowed_from: RETURNABLE_EQUIPMENT_STATUSES
+    )
+  end
+
+  def returnable?
+    equipment.present? && status.in?(RETURNABLE_EQUIPMENT_STATUSES)
   end
 
   def self.build_for_venue(attributes = {})
@@ -43,5 +71,15 @@ class Booking < ApplicationRecord
       "booking_status_user_#{user_id}",
       { booking_id: id, status: status, status_label: status.titleize }
     )
+  end
+
+  def transition_status!(target_status:, allowed_from:, extra_attributes: {})
+    current_status = status
+    unless allowed_from.include?(current_status)
+      errors.add(:status, "cannot transition from #{current_status} to #{target_status}")
+      raise ActiveRecord::RecordInvalid, self
+    end
+
+    update!({ status: target_status }.merge(extra_attributes))
   end
 end

--- a/app/views/bookings/my.html.erb
+++ b/app/views/bookings/my.html.erb
@@ -28,7 +28,7 @@
             <% end %>
             <td data-booking-id="<%= booking.id %>" data-status="<%= booking.status %>"><%= booking.status.titleize %></td>
             <td>
-              <% if booking.equipment.present? && booking.approved? %>
+              <% if booking.returnable? %>
                 <%= button_to "Mark as Returned", mark_returned_booking_path(booking), method: :patch, data: { turbo: false } %>
               <% end %>
             </td>

--- a/spec/models/booking_spec.rb
+++ b/spec/models/booking_spec.rb
@@ -79,6 +79,44 @@ RSpec.describe Booking, type: :model do
     end
   end
 
+  describe 'status transitions' do
+    it 'allows approval only from pending status' do
+      booking = create(:booking, status: :rejected)
+
+      expect { booking.approve! }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(booking.reload.status).to eq('rejected')
+    end
+
+    it 'allows rejection only from pending status' do
+      booking = create(:booking, status: :approved)
+
+      expect { booking.reject!('Maintenance') }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(booking.reload.status).to eq('approved')
+    end
+
+    it 'allows approved equipment bookings to be marked as returned' do
+      booking = create(:equipment_booking, status: :approved)
+
+      booking.mark_returned!
+
+      expect(booking.reload.status).to eq('returned')
+    end
+
+    it 'does not allow venue bookings to be marked as returned' do
+      booking = create(:booking, status: :approved)
+
+      expect { booking.mark_returned! }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(booking.reload.status).to eq('approved')
+    end
+
+    it 'does not allow pending equipment bookings to be marked as returned' do
+      booking = create(:equipment_booking, status: :pending)
+
+      expect { booking.mark_returned! }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(booking.reload.status).to eq('pending')
+    end
+  end
+
   describe 'status broadcasts' do
     it 'broadcasts status payload when status changes' do
       booking = create(:booking, status: :pending)

--- a/spec/requests/bookings_spec.rb
+++ b/spec/requests/bookings_spec.rb
@@ -277,4 +277,37 @@ RSpec.describe "/bookings", type: :request do
       expect(booking.reload.venue_id).to eq(own_venue.id)
     end
   end
+
+  describe "PATCH /bookings/:id/mark_returned" do
+    it "allows users to return approved equipment bookings" do
+      equipment = create(:equipment, tenant: tenant)
+      booking = create(:equipment_booking, user: user, equipment: equipment, status: :approved)
+
+      patch mark_returned_booking_path(booking)
+
+      expect(response).to redirect_to(my_bookings_path)
+      expect(booking.reload.status).to eq("returned")
+    end
+
+    it "blocks returning venue bookings" do
+      booking = create(:booking, user: user, venue: venue, status: :approved)
+
+      patch mark_returned_booking_path(booking)
+
+      expect(response).to redirect_to(my_bookings_path)
+      expect(flash[:alert]).to include("can only be marked as returned")
+      expect(booking.reload.status).to eq("approved")
+    end
+
+    it "blocks returning equipment bookings that are not approved or borrowed" do
+      equipment = create(:equipment, tenant: tenant)
+      booking = create(:equipment_booking, user: user, equipment: equipment, status: :pending)
+
+      patch mark_returned_booking_path(booking)
+
+      expect(response).to redirect_to(my_bookings_path)
+      expect(flash[:alert]).to include("cannot transition from pending to returned")
+      expect(booking.reload.status).to eq("pending")
+    end
+  end
 end


### PR DESCRIPTION
Constrain approve/reject/return transitions to valid states, route mark-returned through domain logic, and surface transition errors gracefully in controllers.