### PR TITLE
Complete approval workflow states, cancellation flow, and audit trail

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ Additional cross-tenant test accounts are also created by seeds:
 | **Society Member** | New Asia College | `member.newasia@cuhk.edu.hk` | `Password1!` |
 | **Society Member** | Wu Yee Sun College | `member.wys@cuhk.edu.hk` | `Password1!` |
 
+## Feature Ownership (Process Evidence)
+
+### Member 1 (Lam Chun Yu / `tylerjlcy`)
+- Approval workflow completion: booking lifecycle states and transition rules
+- Society-member booking cancellation flow (`My Bookings`)
+- Approval audit trail persistence (`ApprovalStep`) and related tests
+- Approval workflow regression coverage (RSpec + Cucumber)
+
 ## Deployment (Azure VM)
 
 Production URL: [https://csci3100.tylerl.cyou](https://csci3100.tylerl.cyou)

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -3,8 +3,8 @@ class BookingsController < ApplicationController
   TIMETABLE_END_HOUR = 22
 
   before_action :require_student_for_edit!, only: %i[ edit update ]
-  before_action :require_student_for_my!, only: :my
-  before_action :set_booking, only: %i[ show edit update destroy approve reject mark_returned ]
+  before_action :require_student_for_my!, only: %i[ my cancel ]
+  before_action :set_booking, only: %i[ show edit update destroy approve reject mark_returned cancel ]
   before_action :require_admin_or_staff, only: %i[ index approve reject ]
 
   # GET /bookings or /bookings.json
@@ -119,7 +119,16 @@ class BookingsController < ApplicationController
   end
 
   def approve
+    previous_status = @booking.status
+    if two_step_approval_required? && @booking.pending?
+      @booking.start_review!
+      record_approval_step!(action: "start_review", from_status: previous_status, to_status: @booking.status)
+      redirect_to approval_dashboard_path, notice: "Booking moved to under review."
+      return
+    end
+
     @booking.approve!
+    record_approval_step!(action: "approve", from_status: previous_status, to_status: @booking.status)
     send_booking_notification(:approved)
 
     redirect_to approval_dashboard_path, notice: "Booking approved."
@@ -128,13 +137,30 @@ class BookingsController < ApplicationController
   end
 
   def reject
+    previous_status = @booking.status
     reason = params[:rejection_reason].to_s.strip
     @booking.reject!(reason)
+    record_approval_step!(action: "reject", from_status: previous_status, to_status: @booking.status, reason: reason)
     send_booking_notification(:rejected, reason: reason)
 
     redirect_to approval_dashboard_path, notice: "Booking rejected."
   rescue ActiveRecord::RecordInvalid => e
     redirect_to approval_dashboard_path, alert: booking_transition_error_message(e, "Booking could not be rejected.")
+  end
+
+  def cancel
+    unless @booking.cancelable_by_owner?
+      redirect_to my_bookings_path, alert: "This booking cannot be cancelled."
+      return
+    end
+
+    previous_status = @booking.status
+    @booking.cancel!
+    record_approval_step!(action: "cancel", from_status: previous_status, to_status: @booking.status)
+
+    redirect_to my_bookings_path, notice: "Booking cancelled."
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to my_bookings_path, alert: booking_transition_error_message(e, "Booking could not be cancelled.")
   end
 
   def mark_returned
@@ -234,6 +260,24 @@ class BookingsController < ApplicationController
       end
     end
 
+    def two_step_approval_required?
+      approval_tenant_for(@booking)&.two_step?
+    end
+
+    def approval_tenant_for(booking)
+      booking.user&.tenant || booking.venue&.tenant || booking.equipment&.tenant
+    end
+
+    def record_approval_step!(action:, from_status:, to_status:, reason: nil)
+      @booking.approval_steps.create!(
+        actor: current_user,
+        action: action,
+        from_status: from_status,
+        to_status: to_status,
+        reason: reason.presence
+      )
+    end
+
     def unauthorized_booking_redirect_path
       return approval_dashboard_path if action_name.in?(["approve", "reject"])
 
@@ -272,8 +316,8 @@ class BookingsController < ApplicationController
       scope = Booking.where(venue_id: selected_venue_id)
                      .where("start_time < ? AND end_time > ?", day_end, day_start)
       if Booking.defined_enums.key?("status")
-        rejected_status = Booking.statuses["rejected"]
-        scope = scope.where.not(status: rejected_status) if rejected_status
+        non_blocking_statuses = Booking.non_blocking_venue_status_values
+        scope = scope.where.not(status: non_blocking_statuses) if non_blocking_statuses.any?
       end
       scope
     end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -5,10 +5,12 @@ class DashboardsController < ApplicationController
   end
 
   def approvals
-    @bookings = Booking.includes(:venue, :user).pending
+    @bookings = Booking.awaiting_approval
+                       .where.not(venue_id: nil)
+                       .includes(:venue, :user, approval_steps: :actor)
 
     if current_user.staff?
-      @bookings = @bookings.for_tenant(current_user.tenant)
+      @bookings = @bookings.joins(:venue).merge(Venue.visible_to_tenant(current_user.tenant))
     end
 
     @bookings = sort_approval_bookings(@bookings)

--- a/app/models/approval_step.rb
+++ b/app/models/approval_step.rb
@@ -1,0 +1,11 @@
+class ApprovalStep < ApplicationRecord
+  ACTIONS = %w[start_review approve reject cancel].freeze
+
+  belongs_to :booking
+  belongs_to :actor, class_name: "User", inverse_of: :approval_steps
+
+  validates :action, presence: true, inclusion: { in: ACTIONS }
+  validates :from_status, presence: true, inclusion: { in: ->(_) { Booking.statuses.keys } }
+  validates :to_status, presence: true, inclusion: { in: ->(_) { Booking.statuses.keys } }
+  validates :reason, length: { maximum: 500 }, allow_blank: true
+end

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,20 +1,33 @@
 class Booking < ApplicationRecord
-  APPROVABLE_FROM_STATUSES = %w[pending].freeze
-  REJECTABLE_FROM_STATUSES = %w[pending].freeze
+  REVIEWABLE_FROM_STATUSES = %w[pending].freeze
+  APPROVABLE_FROM_STATUSES = %w[pending under_review].freeze
+  REJECTABLE_FROM_STATUSES = %w[pending under_review].freeze
+  CANCELLABLE_FROM_STATUSES = %w[pending under_review approved].freeze
   RETURNABLE_EQUIPMENT_STATUSES = %w[approved borrowed].freeze
+  NON_BLOCKING_VENUE_STATUSES = %w[rejected cancelled].freeze
 
   belongs_to :user
   belongs_to :equipment, optional: true
   belongs_to :venue, optional: true
+  has_many :approval_steps, dependent: :destroy
 
-  enum :status, { pending: 0, approved: 1, rejected: 2, borrowed: 3, returned: 4 }
+  enum :status,
+       { pending: 0, approved: 1, rejected: 2, borrowed: 3, returned: 4, under_review: 5, cancelled: 6 }
 
   after_initialize :set_default_status, if: :new_record?
   after_update_commit :broadcast_status_change, if: :saved_change_to_status?
 
   scope :venue_bookings, -> { where(type: "VenueBooking") }
   scope :equipment_bookings, -> { where(type: "EquipmentBooking") }
+  scope :awaiting_approval, -> { where(status: statuses.values_at("pending", "under_review").compact) }
   scope :for_tenant, ->(tenant) { BookingScopeQuery.for_tenant(tenant) }
+
+  def start_review!
+    transition_status!(
+      target_status: :under_review,
+      allowed_from: REVIEWABLE_FROM_STATUSES
+    )
+  end
 
   def approve!
     transition_status!(
@@ -30,6 +43,17 @@ class Booking < ApplicationRecord
       allowed_from: REJECTABLE_FROM_STATUSES,
       extra_attributes: { rejection_reason: reason }
     )
+  end
+
+  def cancel!
+    transition_status!(
+      target_status: :cancelled,
+      allowed_from: CANCELLABLE_FROM_STATUSES
+    )
+  end
+
+  def cancelable_by_owner?
+    status.in?(CANCELLABLE_FROM_STATUSES) && starts_in_future?
   end
 
   def mark_returned!
@@ -54,6 +78,10 @@ class Booking < ApplicationRecord
 
   def self.build_for_equipment(attributes = {})
     EquipmentBooking.new(attributes)
+  end
+
+  def self.non_blocking_venue_status_values
+    statuses.values_at(*NON_BLOCKING_VENUE_STATUSES).compact
   end
 
   def to_partial_path
@@ -81,5 +109,15 @@ class Booking < ApplicationRecord
     end
 
     update!({ status: target_status }.merge(extra_attributes))
+  end
+
+  def starts_in_future?
+    if venue.present? && start_time.present?
+      start_time > Time.current
+    elsif equipment.present? && start_date.present?
+      start_date >= Date.current
+    else
+      false
+    end
   end
 end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -1,5 +1,5 @@
 class Equipment < ApplicationRecord
-  INVENTORY_HOLDING_STATUSES = %w[pending approved borrowed].freeze
+  INVENTORY_HOLDING_STATUSES = %w[pending under_review approved borrowed].freeze
   self.table_name = "equipment"
 
   belongs_to :tenant

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -2,8 +2,11 @@ class Tenant < ApplicationRecord
   has_many :users, dependent: :nullify
   has_many :equipment, dependent: :destroy
 
+  enum :approval_mode, { one_step: 0, two_step: 1 }, default: :one_step
+
   validates :name, presence: true
   validates :slug, presence: true, uniqueness: true
+  validates :approval_mode, presence: true
 
   scope :university, -> { where("name LIKE '%niversity%' OR name LIKE '%NIVERSITY%'").or(where(slug: "university")) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :bookings, dependent: :destroy
   has_many :venue_bookings, class_name: "VenueBooking", dependent: :destroy
   has_many :equipment_bookings, class_name: "EquipmentBooking", dependent: :destroy
+  has_many :approval_steps, foreign_key: :actor_id, inverse_of: :actor, dependent: :restrict_with_exception
   has_many :api_keys, dependent: :destroy
 
   enum :role, { society_member: 0, staff: 1, admin: 2 }

--- a/app/services/booking_conflict_checker.rb
+++ b/app/services/booking_conflict_checker.rb
@@ -18,7 +18,7 @@ class BookingConflictChecker
 
     return scope unless Booking.defined_enums.key?("status")
 
-    rejected_status = Booking.statuses["rejected"]
-    rejected_status ? scope.where.not(status: rejected_status) : scope
+    non_blocking_statuses = Booking.non_blocking_venue_status_values
+    non_blocking_statuses.any? ? scope.where.not(status: non_blocking_statuses) : scope
   end
 end

--- a/app/views/bookings/my.html.erb
+++ b/app/views/bookings/my.html.erb
@@ -28,6 +28,9 @@
             <% end %>
             <td data-booking-id="<%= booking.id %>" data-status="<%= booking.status %>"><%= booking.status.titleize %></td>
             <td>
+              <% if booking.cancelable_by_owner? %>
+                <%= button_to "Cancel Booking", cancel_booking_path(booking), method: :patch, data: { turbo: false, turbo_confirm: "Cancel this booking?" } %>
+              <% end %>
               <% if booking.returnable? %>
                 <%= button_to "Mark as Returned", mark_returned_booking_path(booking), method: :patch, data: { turbo: false } %>
               <% end %>

--- a/app/views/dashboards/approvals.html.erb
+++ b/app/views/dashboards/approvals.html.erb
@@ -1,7 +1,7 @@
 <h1>Approval Dashboard</h1>
 
 <% if @bookings.empty? %>
-  <p>No pending bookings.</p>
+  <p>No bookings awaiting approval.</p>
 <% else %>
   <table id="approvals-table" class="resource-grid-table">
     <thead>
@@ -11,6 +11,7 @@
         <th><%= sortable_header_link("User", "user", current_sort: @sort_column, current_direction: @sort_direction) %></th>
         <th><%= sortable_header_link("Date", "date", current_sort: @sort_column, current_direction: @sort_direction) %></th>
         <th><%= sortable_header_link("Status", "status", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+        <th>Last Action</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -21,9 +22,22 @@
           <td><%= booking.venue.department %></td>
           <td><%= booking.user.email %></td>
           <td><%= booking.start_time.to_date %></td>
-          <td><%= booking.status.titleize %></td>
           <td>
-            <%= button_to "Approve", approve_booking_path(booking), method: :patch %>
+            <%= booking.status.titleize %>
+            <% if booking.under_review? && booking.user&.tenant&.two_step? %>
+              (Step 1/2)
+            <% end %>
+          </td>
+          <td>
+            <% latest_step = booking.approval_steps.max_by(&:created_at) %>
+            <% if latest_step.present? %>
+              <%= "#{latest_step.action.humanize} by #{latest_step.actor.email}" %>
+            <% else %>
+              -
+            <% end %>
+          </td>
+          <td>
+            <%= button_to(booking.under_review? ? "Approve (Final)" : "Approve", approve_booking_path(booking), method: :patch) %>
             <%= form_with url: reject_booking_path(booking), method: :patch, local: true, class: "inline-reject-form" do |f| %>
               <%= f.text_field :rejection_reason, placeholder: "Reason", size: 20 %>
               <%= f.submit "Reject" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     member do
       patch :approve
       patch :reject
+      patch :cancel
       patch :mark_returned
     end
     collection do

--- a/db/migrate/20260406010001_add_approval_mode_to_tenants.rb
+++ b/db/migrate/20260406010001_add_approval_mode_to_tenants.rb
@@ -1,0 +1,5 @@
+class AddApprovalModeToTenants < ActiveRecord::Migration[8.1]
+  def change
+    add_column :tenants, :approval_mode, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20260406010002_create_approval_steps.rb
+++ b/db/migrate/20260406010002_create_approval_steps.rb
@@ -1,0 +1,16 @@
+class CreateApprovalSteps < ActiveRecord::Migration[8.1]
+  def change
+    create_table :approval_steps do |t|
+      t.references :booking, null: false, foreign_key: true
+      t.references :actor, null: false, foreign_key: { to_table: :users }
+      t.string :action, null: false
+      t.string :from_status, null: false
+      t.string :to_status, null: false
+      t.text :reason
+
+      t.timestamps
+    end
+
+    add_index :approval_steps, [:booking_id, :created_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_06_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_06_010002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -25,6 +25,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_06_000000) do
     t.bigint "user_id", null: false
     t.index ["token"], name: "index_api_keys_on_token", unique: true
     t.index ["user_id"], name: "index_api_keys_on_user_id"
+  end
+
+  create_table "approval_steps", force: :cascade do |t|
+    t.string "action", null: false
+    t.bigint "actor_id", null: false
+    t.bigint "booking_id", null: false
+    t.datetime "created_at", null: false
+    t.string "from_status", null: false
+    t.text "reason"
+    t.string "to_status", null: false
+    t.datetime "updated_at", null: false
+    t.index ["actor_id"], name: "index_approval_steps_on_actor_id"
+    t.index ["booking_id", "created_at"], name: "index_approval_steps_on_booking_id_and_created_at"
+    t.index ["booking_id"], name: "index_approval_steps_on_booking_id"
   end
 
   create_table "bookings", force: :cascade do |t|
@@ -64,6 +78,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_06_000000) do
   end
 
   create_table "tenants", force: :cascade do |t|
+    t.integer "approval_mode", default: 0, null: false
     t.datetime "created_at", null: false
     t.text "description"
     t.string "name", null: false
@@ -96,6 +111,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_06_000000) do
   end
 
   add_foreign_key "api_keys", "users"
+  add_foreign_key "approval_steps", "bookings"
+  add_foreign_key "approval_steps", "users", column: "actor_id"
   add_foreign_key "bookings", "equipment"
   add_foreign_key "bookings", "users"
   add_foreign_key "bookings", "venues"

--- a/features/approval_workflow.feature
+++ b/features/approval_workflow.feature
@@ -25,6 +25,14 @@ Feature: Booking Approval Workflow
     Then the booking status should be "Approved"
     And "student@link.cuhk.edu.hk" should receive a confirmation email
 
+  Scenario: Two-step tenant requires two approvals before final approval
+    Given tenant "Science Faculty" uses two-step approval
+    And I am logged in as "staff@link.cuhk.edu.hk"
+    When I approve the booking for "Room 101" on "2026-04-20"
+    Then the booking status should be "Under review"
+    When I approve the booking for "Room 101" on "2026-04-20"
+    Then the booking status should be "Approved"
+
   Scenario: Staff cannot manage bookings from another department
     Given I am logged in as "staff@link.cuhk.edu.hk"
     And there is a pending booking for "LT1" which belongs to "Arts Faculty"
@@ -43,6 +51,12 @@ Feature: Booking Approval Workflow
     When I visit the approval dashboard
     Then I should see "You are not authorized to perform this action."
     And I should not be on the approval dashboard page
+
+  Scenario: Society member can cancel own pending booking
+    Given I am logged in as "student@link.cuhk.edu.hk"
+    When I visit my bookings page
+    And I click "Cancel Booking"
+    Then the booking for "Room 101" on "2026-04-20" should remain "Cancelled"
 
   @javascript
   Scenario: Student is notified in real-time when booking is approved

--- a/features/step_definitions/approval_workflow_steps.rb
+++ b/features/step_definitions/approval_workflow_steps.rb
@@ -22,6 +22,11 @@ Given("{string} has a pending booking for {string} on {string}") do |email, venu
   )
 end
 
+Given("tenant {string} uses two-step approval") do |tenant_name|
+  tenant = Tenant.find_by!(name: tenant_name)
+  tenant.update!(approval_mode: :two_step)
+end
+
 When("I visit the approval dashboard") do
   visit approval_dashboard_path
 end
@@ -50,7 +55,8 @@ end
 
 Then("the booking status should be {string}") do |status|
   booking = @current_booking || Booking.last
-  expect(booking.reload.status).to eq(status.downcase)
+  normalized_status = status.downcase.tr(" ", "_")
+  expect(booking.reload.status).to eq(normalized_status)
 end
 
 Then("{string} should receive a confirmation email") do |email|
@@ -112,7 +118,8 @@ Then("the booking for {string} on {string} should remain {string}") do |venue_na
                    .where(start_time: Time.zone.parse(date).all_day)
                    .first
 
-  expect(booking.reload.status).to eq(status.downcase)
+  normalized_status = status.downcase.tr(" ", "_")
+  expect(booking.reload.status).to eq(normalized_status)
 end
 
 Given("I am viewing {string}") do |page_name|

--- a/spec/factories/approval_steps.rb
+++ b/spec/factories/approval_steps.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :approval_step do
+    association :booking
+    association :actor, factory: :user
+    action { "approve" }
+    from_status { "pending" }
+    to_status { "approved" }
+    reason { nil }
+  end
+end

--- a/spec/factories/tenants.rb
+++ b/spec/factories/tenants.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     name { "Computer Science Department" }
     sequence(:slug) { |n| "cs-dept-#{n}" }
     description { "A department at CUHK" }
+
+    trait :two_step do
+      approval_mode { :two_step }
+    end
   end
 end

--- a/spec/models/approval_step_spec.rb
+++ b/spec/models/approval_step_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe ApprovalStep, type: :model do
+  describe "validations" do
+    it "is valid with supported action and statuses" do
+      expect(build(:approval_step)).to be_valid
+    end
+
+    it "is invalid with unsupported action" do
+      step = build(:approval_step, action: "archive")
+
+      expect(step).not_to be_valid
+      expect(step.errors[:action]).to include("is not included in the list")
+    end
+
+    it "is invalid with unsupported statuses" do
+      step = build(:approval_step, from_status: "unknown", to_status: "unknown")
+
+      expect(step).not_to be_valid
+      expect(step.errors[:from_status]).to include("is not included in the list")
+      expect(step.errors[:to_status]).to include("is not included in the list")
+    end
+  end
+
+  describe "associations" do
+    it "belongs to booking" do
+      expect(described_class.reflect_on_association(:booking).macro).to eq(:belongs_to)
+    end
+
+    it "belongs to actor" do
+      association = described_class.reflect_on_association(:actor)
+      expect(association.macro).to eq(:belongs_to)
+      expect(association.class_name).to eq("User")
+    end
+  end
+end

--- a/spec/models/booking_spec.rb
+++ b/spec/models/booking_spec.rb
@@ -80,18 +80,58 @@ RSpec.describe Booking, type: :model do
   end
 
   describe 'status transitions' do
-    it 'allows approval only from pending status' do
+    it 'allows approval from under_review status' do
+      booking = create(:booking, status: :under_review)
+
+      booking.approve!
+
+      expect(booking.reload.status).to eq('approved')
+    end
+
+    it 'blocks approval from rejected status' do
       booking = create(:booking, status: :rejected)
 
       expect { booking.approve! }.to raise_error(ActiveRecord::RecordInvalid)
       expect(booking.reload.status).to eq('rejected')
     end
 
-    it 'allows rejection only from pending status' do
+    it 'allows transition to under_review from pending status' do
+      booking = create(:booking, status: :pending)
+
+      booking.start_review!
+
+      expect(booking.reload.status).to eq('under_review')
+    end
+
+    it 'allows rejection from under_review status' do
+      booking = create(:booking, status: :under_review)
+
+      booking.reject!('Capacity issue')
+
+      expect(booking.reload.status).to eq('rejected')
+      expect(booking.rejection_reason).to eq('Capacity issue')
+    end
+
+    it 'blocks rejection from approved status' do
       booking = create(:booking, status: :approved)
 
       expect { booking.reject!('Maintenance') }.to raise_error(ActiveRecord::RecordInvalid)
       expect(booking.reload.status).to eq('approved')
+    end
+
+    it 'allows cancellation from pending status' do
+      booking = create(:booking, status: :pending)
+
+      booking.cancel!
+
+      expect(booking.reload.status).to eq('cancelled')
+    end
+
+    it 'blocks cancellation from returned status' do
+      booking = create(:equipment_booking, status: :returned)
+
+      expect { booking.cancel! }.to raise_error(ActiveRecord::RecordInvalid)
+      expect(booking.reload.status).to eq('returned')
     end
 
     it 'allows approved equipment bookings to be marked as returned' do
@@ -114,6 +154,26 @@ RSpec.describe Booking, type: :model do
 
       expect { booking.mark_returned! }.to raise_error(ActiveRecord::RecordInvalid)
       expect(booking.reload.status).to eq('pending')
+    end
+  end
+
+  describe '#cancelable_by_owner?' do
+    it 'returns true for pending future venue bookings' do
+      booking = create(:booking,
+                       status: :pending,
+                       start_time: 2.days.from_now.change(hour: 10, min: 0),
+                       end_time: 2.days.from_now.change(hour: 12, min: 0))
+
+      expect(booking.cancelable_by_owner?).to be(true)
+    end
+
+    it 'returns false for past venue bookings' do
+      booking = create(:booking,
+                       status: :pending,
+                       start_time: 2.days.ago.change(hour: 10, min: 0),
+                       end_time: 2.days.ago.change(hour: 12, min: 0))
+
+      expect(booking.cancelable_by_owner?).to be(false)
     end
   end
 

--- a/spec/requests/bookings_spec.rb
+++ b/spec/requests/bookings_spec.rb
@@ -286,16 +286,22 @@ RSpec.describe "/bookings", type: :request do
       log_in_as(staff_user)
     end
 
-    it "shows only pending bookings in the staff tenant" do
+    it "shows bookings awaiting approval in the staff tenant" do
       scoped_venue = create(:venue, name: "Room 101", department: science_tenant.name, tenant: science_tenant)
+      scoped_under_review_venue = create(:venue, name: "Room 102", department: science_tenant.name, tenant: science_tenant)
+      scoped_approved_venue = create(:venue, name: "Room 103", department: science_tenant.name, tenant: science_tenant)
       foreign_venue = create(:venue, name: "LT1", department: arts_tenant.name, tenant: arts_tenant)
       create(:booking, venue: scoped_venue, user: create(:user, tenant: science_tenant), status: :pending)
+      create(:booking, venue: scoped_under_review_venue, user: create(:user, tenant: science_tenant), status: :under_review)
+      create(:booking, venue: scoped_approved_venue, user: create(:user, tenant: science_tenant), status: :approved)
       create(:booking, venue: foreign_venue, user: create(:user, tenant: arts_tenant), status: :pending)
 
       get approval_dashboard_path
 
       expect(response).to be_successful
       expect(response.body).to include("Room 101")
+      expect(response.body).to include("Room 102")
+      expect(response.body).not_to include("Room 103")
       expect(response.body).not_to include("LT1")
     end
 
@@ -342,6 +348,8 @@ RSpec.describe "/bookings", type: :request do
 
       expect(response).to redirect_to(approval_dashboard_path)
       expect(booking.reload.status).to eq("approved")
+      expect(booking.approval_steps.count).to eq(1)
+      expect(booking.approval_steps.last.action).to eq("approve")
     end
 
     it "rejects approval for bookings outside staff tenant" do
@@ -352,6 +360,35 @@ RSpec.describe "/bookings", type: :request do
 
       expect(response).to redirect_to(approval_dashboard_path)
       expect(booking.reload.status).to eq("pending")
+    end
+
+    context "when tenant uses two-step approval" do
+      before do
+        science_tenant.update!(approval_mode: :two_step)
+      end
+
+      it "moves pending bookings to under_review on first approval" do
+        scoped_venue = create(:venue, department: science_tenant.name, tenant: science_tenant)
+        booking = create(:booking, venue: scoped_venue, user: create(:user, tenant: science_tenant), status: :pending)
+
+        patch approve_booking_path(booking)
+
+        expect(response).to redirect_to(approval_dashboard_path)
+        expect(booking.reload.status).to eq("under_review")
+        expect(booking.approval_steps.count).to eq(1)
+        expect(booking.approval_steps.last.action).to eq("start_review")
+      end
+
+      it "requires a second approval to reach approved status" do
+        scoped_venue = create(:venue, department: science_tenant.name, tenant: science_tenant)
+        booking = create(:booking, venue: scoped_venue, user: create(:user, tenant: science_tenant), status: :pending)
+
+        patch approve_booking_path(booking)
+        patch approve_booking_path(booking)
+
+        expect(booking.reload.status).to eq("approved")
+        expect(booking.approval_steps.pluck(:action)).to eq(%w[start_review approve])
+      end
     end
   end
 
@@ -373,6 +410,8 @@ RSpec.describe "/bookings", type: :request do
       expect(response).to redirect_to(approval_dashboard_path)
       expect(booking.reload.status).to eq("rejected")
       expect(booking.rejection_reason).to eq("Maintenance")
+      expect(booking.approval_steps.count).to eq(1)
+      expect(booking.approval_steps.last.action).to eq("reject")
     end
 
     it "blocks staff from rejecting bookings outside their tenant" do
@@ -385,6 +424,67 @@ RSpec.describe "/bookings", type: :request do
       expect(flash[:alert]).to eq("You are not authorized to access this booking.")
       expect(booking.reload.status).to eq("pending")
       expect(booking.rejection_reason).to be_nil
+    end
+
+    it "allows rejecting bookings in under_review state" do
+      scoped_venue = create(:venue, department: science_tenant.name, tenant: science_tenant)
+      booking = create(:booking, venue: scoped_venue, user: create(:user, tenant: science_tenant), status: :under_review)
+
+      patch reject_booking_path(booking), params: { rejection_reason: "No staff available" }
+
+      expect(response).to redirect_to(approval_dashboard_path)
+      expect(booking.reload.status).to eq("rejected")
+      expect(booking.rejection_reason).to eq("No staff available")
+    end
+  end
+
+  describe "PATCH /bookings/:id/cancel" do
+    let(:owner) { create(:user, tenant: tenant) }
+
+    before do
+      log_in_as(owner)
+    end
+
+    it "allows owner to cancel an eligible booking" do
+      booking = create(:booking,
+                       user: owner,
+                       venue: venue,
+                       status: :pending,
+                       start_time: 2.days.from_now.change(hour: 10, min: 0),
+                       end_time: 2.days.from_now.change(hour: 12, min: 0))
+
+      patch cancel_booking_path(booking)
+
+      expect(response).to redirect_to(my_bookings_path)
+      expect(booking.reload.status).to eq("cancelled")
+      expect(booking.approval_steps.count).to eq(1)
+      expect(booking.approval_steps.last.action).to eq("cancel")
+    end
+
+    it "blocks owner from cancelling past bookings" do
+      booking = create(:booking,
+                       user: owner,
+                       venue: venue,
+                       status: :pending,
+                       start_time: 2.days.ago.change(hour: 10, min: 0),
+                       end_time: 2.days.ago.change(hour: 12, min: 0))
+
+      patch cancel_booking_path(booking)
+
+      expect(response).to redirect_to(my_bookings_path)
+      expect(flash[:alert]).to eq("This booking cannot be cancelled.")
+      expect(booking.reload.status).to eq("pending")
+    end
+
+    it "blocks cancelling another user's booking" do
+      other_user = create(:user, tenant: tenant)
+      booking = create(:booking, user: other_user, venue: venue, status: :pending)
+
+      patch cancel_booking_path(booking)
+
+      expect(response).to redirect_to(my_bookings_path)
+      expect(flash[:alert]).to eq("You are not authorized to access this booking.")
+      expect(booking.reload.status).to eq("pending")
     end
   end
 

--- a/spec/services/booking_conflict_checker_spec.rb
+++ b/spec/services/booking_conflict_checker_spec.rb
@@ -44,4 +44,25 @@ RSpec.describe BookingConflictChecker do
 
     expect(described_class.new(booking).conflict_exists?).to be(false)
   end
+
+  it 'ignores cancelled overlapping bookings' do
+    create(
+      :booking,
+      user: user,
+      venue: venue,
+      status: :cancelled,
+      start_time: Time.zone.parse('2026-04-10 10:00:00'),
+      end_time: Time.zone.parse('2026-04-10 12:00:00')
+    )
+
+    booking = build(
+      :booking,
+      user: user,
+      venue: venue,
+      start_time: Time.zone.parse('2026-04-10 11:00:00'),
+      end_time: Time.zone.parse('2026-04-10 13:00:00')
+    )
+
+    expect(described_class.new(booking).conflict_exists?).to be(false)
+  end
 end


### PR DESCRIPTION
## What I changed
- Completed approval workflow lifecycle support:
  - Added `under_review` and `cancelled` booking statuses.
  - Added tenant-level approval mode (`one_step`, `two_step`).
  - Added transition behavior for one-step and two-step approvals.
- Added member cancellation flow:
  - New route/action: `PATCH /bookings/:id/cancel`.
  - "Cancel Booking" action on **My Bookings** when eligible.
- Added approval audit trail:
  - New `ApprovalStep` model + migrations.
  - Records actor, action, from/to status, and reason for approve/reject/cancel/start_review.
- Updated approval dashboard behavior and UI:
  - Shows bookings awaiting approval (`pending` + `under_review`) for venues.
  - Shows latest approval action context per booking.
- Expanded tests and BDD coverage for the new workflow behavior.
- Updated README feature ownership entry for Member 1 scope.

## Why these changes
The previous workflow covered only a subset of approval lifecycle behavior. These changes close the gaps needed for a full approval flow (including two-step approval tenants), improve traceability through an audit trail, and give members a controlled cancellation path.

## Main file changes
- **Models**: `app/models/booking.rb`, `app/models/tenant.rb`, `app/models/approval_step.rb`, `app/models/equipment.rb`, `app/models/user.rb`
- **Controllers**: `app/controllers/bookings_controller.rb`, `app/controllers/dashboards_controller.rb`
- **Views**: `app/views/dashboards/approvals.html.erb`, `app/views/bookings/my.html.erb`
- **Routing**: `config/routes.rb`
- **DB**: `db/migrate/20260406010001_add_approval_mode_to_tenants.rb`, `db/migrate/20260406010002_create_approval_steps.rb`, `db/schema.rb`
- **Tests/Features**: updated request/model/service specs and approval workflow cucumber steps/scenarios

## What collaborators should watch out for
1. **Run migrations** after pulling this branch (`bin/rails db:prepare` and test DB prepare) because `tenants` and new `approval_steps` table changed.
2. **Status assumptions changed**: logic that previously expected approvals directly from `pending` may now encounter `under_review` for two-step tenants.
3. **Approval dashboard semantics changed**: it now lists bookings awaiting approval (not only pending).
4. **Cancellation behavior is now explicit** for eligible owner bookings; UI/actions depending on old status-only flow should be retested.
5. There is still a **pre-existing flaky/failing realtime @javascript cucumber scenario** in full-suite runs unrelated to this refactor.
