### PR TITLE
Sync production bootstrap passwords for root staff and admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The deploy workflow runs automatically after `CI` succeeds on `main`, and can al
 | `RAILS_MASTER_KEY` | Content of `config/master.key` |
 | `POSTGRES_PASSWORD` | Password for the production Postgres container |
 | `SECRET_KEY_BASE` | Required (`openssl rand -hex 64`) |
-| `BOOTSTRAP_ACCOUNT_PASSWORD` | **Required for production deploys.** Password used when bootstrap admin/root accounts are first created in production. Deploy fails if unset. |
+| `BOOTSTRAP_ACCOUNT_PASSWORD` | **Required for production deploys.** Password used for bootstrap admin/root accounts during production seed runs (kept in sync with this value). Deploy fails if unset. |
 
 ### 2. Deploy
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -216,6 +216,7 @@ equipments = [
 ]
 
 bootstrap_password = ENV["BOOTSTRAP_ACCOUNT_PASSWORD"]
+synchronize_bootstrap_password = Rails.env.production?
 
 if Rails.env.production? && bootstrap_password.blank?
   raise "BOOTSTRAP_ACCOUNT_PASSWORD must be set in production."
@@ -268,7 +269,7 @@ admin = User.find_or_initialize_by(email: "admin@link.cuhk.edu.hk")
 admin.role = :admin
 admin.tenant = tenants["University"]
 
-if admin.new_record? || admin.password_digest.blank?
+if synchronize_bootstrap_password || admin.new_record? || admin.password_digest.blank?
   admin.password = bootstrap_password
   admin.password_confirmation = bootstrap_password
 end
@@ -282,7 +283,7 @@ root_staff_emails.each do |college_name, email|
   user.is_root_account = true
   user.tenant = tenants.fetch(college_name)
 
-  if user.new_record? || user.password_digest.blank?
+  if synchronize_bootstrap_password || user.new_record? || user.password_digest.blank?
     user.password = bootstrap_password
     user.password_confirmation = bootstrap_password
   end


### PR DESCRIPTION
## Problem
After enabling required `BOOTSTRAP_ACCOUNT_PASSWORD`, admin could log in with the secret but existing root staff accounts could not.

## Root cause
In `db/seeds.rb`, bootstrap passwords were only assigned when an account was new or had an empty password digest:
- `if user.new_record? || user.password_digest.blank?`

So previously created root staff users kept their old password across deploys.

## Fix
For production seed runs, always sync bootstrap account passwords to `BOOTSTRAP_ACCOUNT_PASSWORD`:
- added `synchronize_bootstrap_password = Rails.env.production?`
- applied to both admin and root staff password assignment conditions

This keeps bootstrap credentials consistent with the configured secret after each deploy.

## Docs
Updated README secret description to clarify that production seed runs keep bootstrap admin/root passwords in sync with `BOOTSTRAP_ACCOUNT_PASSWORD`.

## Validation
- `bin/rubocop db/seeds.rb`
- `bin/rails db:seed`
- `bundle exec rspec`
- `bundle exec cucumber`