### PR TITLE
Enforce single active session and improve auth UX (#63, #77)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -188,6 +188,89 @@ p { margin-bottom: 0.5rem; }
 
 .auth-footer a { font-weight: 600; }
 
+.domain-email-input {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+}
+
+.domain-email-input input {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.domain-email-suffix {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.8rem;
+  border: 1.5px solid var(--gray-300);
+  border-left: 0;
+  border-top-right-radius: var(--radius);
+  border-bottom-right-radius: var(--radius);
+  background: var(--gray-100);
+  color: var(--gray-600);
+  font-size: 0.88rem;
+  white-space: nowrap;
+}
+
+.form-hint {
+  margin-top: 0.35rem;
+  font-size: 0.82rem;
+  color: var(--gray-500);
+}
+
+.form-inline-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.password-rules {
+  margin: 0.55rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.password-rule {
+  font-size: 0.82rem;
+}
+
+.password-rule.pending {
+  color: #9a3412;
+}
+
+.password-rule.passed {
+  color: #166534;
+}
+
+.password-rules-summary {
+  margin-top: 0.4rem;
+  font-size: 0.82rem;
+  color: #9a3412;
+}
+
+.generated-password-panel {
+  margin-top: 0.55rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px dashed var(--warning);
+  border-radius: var(--radius);
+  background: #fffbeb;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.generated-password-panel code {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.copy-feedback {
+  font-size: 0.78rem;
+  color: var(--gray-600);
+}
+
 /* ===== App Layout (Sidebar + Content) ===== */
 .app-layout {
   display: flex;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -192,9 +192,12 @@ p { margin-bottom: 0.5rem; }
   display: flex;
   align-items: stretch;
   width: 100%;
+  border-radius: var(--radius);
+  overflow: hidden;
 }
 
-.domain-email-input input {
+.auth-card .form-group .domain-email-input input {
+  border-right: 0;
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
@@ -204,7 +207,7 @@ p { margin-bottom: 0.5rem; }
   align-items: center;
   padding: 0 0.8rem;
   border: 1.5px solid var(--gray-300);
-  border-left: 0;
+  border-left: 1.5px solid var(--gray-300);
   border-top-right-radius: var(--radius);
   border-bottom-right-radius: var(--radius);
   background: var(--gray-100);
@@ -227,12 +230,25 @@ p { margin-bottom: 0.5rem; }
 }
 
 .password-rules {
-  margin: 0.55rem 0 0;
-  padding-left: 1.1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.25rem;
 }
 
 .password-rule {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
   font-size: 0.82rem;
+}
+
+.password-rule::before {
+  content: "\2022";
+  font-size: 1rem;
+  line-height: 1;
+  color: currentColor;
 }
 
 .password-rule.pending {
@@ -243,14 +259,27 @@ p { margin-bottom: 0.5rem; }
   color: #166534;
 }
 
+.password-rule.passed::before {
+  content: "\2713";
+  font-weight: 700;
+}
+
 .password-rules-summary {
-  margin-top: 0.4rem;
+  margin: 0.45rem 0 0.35rem;
   font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.password-rules-summary.pending {
   color: #9a3412;
 }
 
+.password-rules-summary.passed {
+  color: #166534;
+}
+
 .generated-password-panel {
-  margin-top: 0.55rem;
+  margin: 0.3rem 0 0.45rem;
   padding: 0.6rem 0.75rem;
   border: 1px dashed var(--warning);
   border-radius: var(--radius);
@@ -259,6 +288,10 @@ p { margin-bottom: 0.5rem; }
   align-items: center;
   gap: 0.55rem;
   flex-wrap: wrap;
+}
+
+.generated-password-panel[hidden] {
+  display: none;
 }
 
 .generated-password-panel code {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,19 @@ class ApplicationController < ActionController::Base
   private
 
   def current_user
-    @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
+    return @current_user if defined?(@current_user)
+
+    @current_user = nil
+    user_id = session[:user_id]
+    return @current_user if user_id.blank?
+
+    user = User.find_by(id: user_id)
+    unless user && user.active_session_token_matches?(session[:active_session_token])
+      reset_session
+      return @current_user
+    end
+
+    @current_user = user
   end
 
   def logged_in?

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -22,7 +22,7 @@ class RegistrationsController < ApplicationController
   end
 
   def create
-    @user = User.new(registration_params)
+    @user = User.new(registration_attributes)
     @user.role = :student
 
     unless registration_tenant_ids.include?(@user.tenant_id)
@@ -121,7 +121,14 @@ class RegistrationsController < ApplicationController
   end
 
   def registration_params
-    params.require(:user).permit(:email, :password, :password_confirmation, :tenant_id)
+    params.require(:user).permit(:email, :email_local_part, :password, :password_confirmation, :tenant_id)
+  end
+
+  def registration_attributes
+    attrs = registration_params.to_h
+    email_input = attrs.delete("email_local_part").presence || attrs["email"]
+    attrs["email"] = User.canonicalize_cuhk_email(email_input)
+    attrs
   end
 
   def pending_signup_payload

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -77,6 +77,7 @@ class RegistrationsController < ApplicationController
       SignupVerificationService.consume_code!(email: @pending_email)
       clear_pending_signup
       reset_session
+      session[:active_session_token] = @user.issue_active_session_token!
       session[:user_id] = @user.id
       redirect_to dashboard_path, notice: "Account created successfully."
     else

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,8 @@ class SessionsController < ApplicationController
   end
 
   def create
-    email = params[:email].to_s.strip.downcase
+    email_input = params[:email_local_part].presence || params[:email]
+    email = User.canonicalize_cuhk_email(email_input)
     user = User.find_by(email: email)
 
     if user&.authenticate(params[:password])

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,9 +9,12 @@ class SessionsController < ApplicationController
     user = User.find_by(email: email)
 
     if user&.authenticate(params[:password])
-      reset_session
-      session[:user_id] = user.id
-      redirect_to dashboard_path, notice: "Logged in successfully."
+      if establish_session_lock!(user)
+        redirect_to dashboard_path, notice: "Logged in successfully."
+      else
+        flash.now[:alert] = "This account is already logged in on another device. Please sign out there first."
+        render :new, status: :conflict
+      end
     else
       flash.now[:alert] = "Invalid email or password."
       render :new, status: :unprocessable_content
@@ -19,7 +22,33 @@ class SessionsController < ApplicationController
   end
 
   def destroy
+    release_session_lock!
     reset_session
     redirect_to login_path, notice: "Logged out successfully."
+  end
+
+  private
+
+  def establish_session_lock!(user)
+    session_token = nil
+
+    user.with_lock do
+      user.reload
+      return false if user.active_session_locked?
+
+      session_token = user.issue_active_session_token!
+    end
+
+    reset_session
+    session[:user_id] = user.id
+    session[:active_session_token] = session_token
+    true
+  end
+
+  def release_session_lock!
+    user = User.find_by(id: session[:user_id])
+    return unless user
+
+    user.clear_active_session_token!(token: session[:active_session_token])
   end
 end

--- a/app/javascript/controllers/domain_lock_email_controller.js
+++ b/app/javascript/controllers/domain_lock_email_controller.js
@@ -1,0 +1,35 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["localPart", "fullPreview"]
+  static values = {
+    domain: { type: String, default: "link.cuhk.edu.hk" }
+  }
+
+  connect() {
+    this.sanitize()
+    this.updatePreview()
+  }
+
+  sanitize() {
+    if (!this.hasLocalPartTarget) {
+      return
+    }
+
+    const rawValue = this.localPartTarget.value.toString()
+    const sanitized = rawValue.split("@", 2)[0].replace(/\s+/g, "")
+    if (sanitized !== rawValue) {
+      this.localPartTarget.value = sanitized
+    }
+  }
+
+  updatePreview() {
+    if (!this.hasFullPreviewTarget || !this.hasLocalPartTarget) {
+      return
+    }
+
+    const localPart = this.localPartTarget.value.toString().trim()
+    const fallback = `yourid@${this.domainValue}`
+    this.fullPreviewTarget.textContent = localPart ? `${localPart}@${this.domainValue}` : fallback
+  }
+}

--- a/app/javascript/controllers/registration_form_controller.js
+++ b/app/javascript/controllers/registration_form_controller.js
@@ -19,6 +19,10 @@ export default class extends Controller {
   ]
 
   connect() {
+    if (this.hasGeneratedPanelTarget) {
+      this.generatedPanelTarget.hidden = true
+    }
+
     this.updateRules()
   }
 
@@ -32,11 +36,7 @@ export default class extends Controller {
     this.applyRuleState(this.minLengthRuleTarget, hasMinimumLength)
     this.applyRuleState(this.confirmationRuleTarget, confirmationMatches)
 
-    if (hasMinimumLength && confirmationMatches) {
-      this.rulesSummaryTarget.textContent = "Password requirements satisfied."
-    } else {
-      this.rulesSummaryTarget.textContent = "Please satisfy all password requirements."
-    }
+    this.applySummaryState(hasMinimumLength && confirmationMatches)
   }
 
   generatePassword(event) {
@@ -73,6 +73,12 @@ export default class extends Controller {
   applyRuleState(ruleNode, passed) {
     ruleNode.classList.toggle("passed", passed)
     ruleNode.classList.toggle("pending", !passed)
+  }
+
+  applySummaryState(passed) {
+    this.rulesSummaryTarget.classList.toggle("passed", passed)
+    this.rulesSummaryTarget.classList.toggle("pending", !passed)
+    this.rulesSummaryTarget.textContent = passed ? "All password requirements satisfied." : "Please satisfy password requirements."
   }
 
   buildPassword() {

--- a/app/javascript/controllers/registration_form_controller.js
+++ b/app/javascript/controllers/registration_form_controller.js
@@ -1,0 +1,113 @@
+import { Controller } from "@hotwired/stimulus"
+
+const PASSWORD_LENGTH = 14
+const UPPERCASE = "ABCDEFGHJKLMNPQRSTUVWXYZ"
+const LOWERCASE = "abcdefghijkmnopqrstuvwxyz"
+const NUMBERS = "23456789"
+const SYMBOLS = "!@#$%^&*()-_=+[]{}?"
+
+export default class extends Controller {
+  static targets = [
+    "password",
+    "passwordConfirmation",
+    "minLengthRule",
+    "confirmationRule",
+    "rulesSummary",
+    "generatedPanel",
+    "generatedPassword",
+    "copyFeedback"
+  ]
+
+  connect() {
+    this.updateRules()
+  }
+
+  updateRules() {
+    const password = this.passwordTarget.value.toString()
+    const confirmation = this.passwordConfirmationTarget.value.toString()
+
+    const hasMinimumLength = password.length >= 8
+    const confirmationMatches = confirmation.length > 0 && password === confirmation
+
+    this.applyRuleState(this.minLengthRuleTarget, hasMinimumLength)
+    this.applyRuleState(this.confirmationRuleTarget, confirmationMatches)
+
+    if (hasMinimumLength && confirmationMatches) {
+      this.rulesSummaryTarget.textContent = "Password requirements satisfied."
+    } else {
+      this.rulesSummaryTarget.textContent = "Please satisfy all password requirements."
+    }
+  }
+
+  generatePassword(event) {
+    event.preventDefault()
+
+    const password = this.buildPassword()
+    this.passwordTarget.value = password
+    this.passwordConfirmationTarget.value = password
+
+    this.generatedPanelTarget.hidden = false
+    this.generatedPasswordTarget.textContent = password
+    this.copyFeedbackTarget.textContent = ""
+
+    this.updateRules()
+  }
+
+  async copyGeneratedPassword(event) {
+    event.preventDefault()
+
+    const password = this.generatedPasswordTarget.textContent.toString().trim()
+    if (!password) {
+      this.copyFeedbackTarget.textContent = "Nothing to copy."
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(password)
+      this.copyFeedbackTarget.textContent = "Copied."
+    } catch (_error) {
+      this.copyFeedbackTarget.textContent = "Copy failed."
+    }
+  }
+
+  applyRuleState(ruleNode, passed) {
+    ruleNode.classList.toggle("passed", passed)
+    ruleNode.classList.toggle("pending", !passed)
+  }
+
+  buildPassword() {
+    const requiredSets = [UPPERCASE, LOWERCASE, NUMBERS, SYMBOLS]
+    const allCharacters = `${UPPERCASE}${LOWERCASE}${NUMBERS}${SYMBOLS}`
+
+    const passwordCharacters = requiredSets.map((set) => this.randomCharacter(set))
+    while (passwordCharacters.length < PASSWORD_LENGTH) {
+      passwordCharacters.push(this.randomCharacter(allCharacters))
+    }
+
+    this.shuffle(passwordCharacters)
+    return passwordCharacters.join("")
+  }
+
+  randomCharacter(characterSet) {
+    return characterSet[this.randomIndex(characterSet.length)]
+  }
+
+  randomIndex(max) {
+    if (window.crypto && window.crypto.getRandomValues) {
+      const values = new Uint32Array(1)
+      window.crypto.getRandomValues(values)
+      return values[0] % max
+    }
+
+    return Math.floor(Math.random() * max)
+  }
+
+  shuffle(array) {
+    for (let i = array.length - 1; i > 0; i -= 1) {
+      const j = this.randomIndex(i + 1)
+      const tmp = array[i]
+      array[i] = array[j]
+      array[j] = tmp
+    }
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@ class User < ApplicationRecord
   scope :root_accounts, -> { where(is_root_account: true) }
 
   SESSION_TOKEN_LENGTH = 64
+  CUHK_EMAIL_DOMAIN = "link.cuhk.edu.hk"
+  CUHK_EMAIL_REGEX = /\A[a-zA-Z0-9._%+-]+@#{Regexp.escape(CUHK_EMAIL_DOMAIN)}\z/i
 
   def root_account?
     is_root_account
@@ -55,7 +57,15 @@ class User < ApplicationRecord
     ActiveSupport::SecurityUtils.secure_compare(active_session_token, submitted_token)
   end
 
-  CUHK_EMAIL_REGEX = /\A[a-zA-Z0-9._%+-]+@link\.cuhk\.edu\.hk\z/i
+  def self.canonicalize_cuhk_email(local_part_or_email)
+    value = local_part_or_email.to_s.strip.downcase
+    return "" if value.blank?
+
+    local_part = value.split("@", 2).first
+    return "" if local_part.blank?
+
+    "#{local_part}@#{CUHK_EMAIL_DOMAIN}"
+  end
 
   validates :email, presence: true,
                     uniqueness: { case_sensitive: false },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,8 @@ class User < ApplicationRecord
 
   scope :root_accounts, -> { where(is_root_account: true) }
 
+  SESSION_TOKEN_LENGTH = 64
+
   def root_account?
     is_root_account
   end
@@ -28,6 +30,29 @@ class User < ApplicationRecord
     return false if admin? && User.admin.count <= 1
 
     true
+  end
+
+  def active_session_locked?
+    active_session_token.present?
+  end
+
+  def issue_active_session_token!
+    token = SecureRandom.hex(SESSION_TOKEN_LENGTH / 2)
+    update!(active_session_token: token)
+    token
+  end
+
+  def clear_active_session_token!(token:)
+    return unless active_session_token_matches?(token)
+
+    update!(active_session_token: nil)
+  end
+
+  def active_session_token_matches?(token)
+    submitted_token = token.to_s
+    return false if active_session_token.blank? || submitted_token.blank?
+
+    ActiveSupport::SecurityUtils.secure_compare(active_session_token, submitted_token)
   end
 
   CUHK_EMAIL_REGEX = /\A[a-zA-Z0-9._%+-]+@link\.cuhk\.edu\.hk\z/i

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -58,25 +58,6 @@
             Generate strong password
           </button>
         </div>
-        <%= f.password_field :password,
-                             required: true,
-                             placeholder: "Create a password",
-                             autocomplete: "new-password",
-                             data: {
-                               registration_form_target: "password",
-                               action: "input->registration-form#updateRules"
-                             } %>
-        <ul class="password-rules">
-          <li class="password-rule pending" data-registration-form-target="minLengthRule">
-            At least 8 characters
-          </li>
-          <li class="password-rule pending" data-registration-form-target="confirmationRule">
-            Matches confirmation password
-          </li>
-        </ul>
-        <p class="password-rules-summary" data-registration-form-target="rulesSummary">
-          Please satisfy all password requirements.
-        </p>
         <div class="generated-password-panel" data-registration-form-target="generatedPanel" hidden>
           <span>Generated password:</span>
           <code data-registration-form-target="generatedPassword"></code>
@@ -87,6 +68,27 @@
           </button>
           <span class="copy-feedback" data-registration-form-target="copyFeedback"></span>
         </div>
+        <%= f.password_field :password,
+                             required: true,
+                             placeholder: "Create a password",
+                             autocomplete: "new-password",
+                             data: {
+                                registration_form_target: "password",
+                                action: "input->registration-form#updateRules"
+                              } %>
+        <p class="password-rules-summary pending"
+           data-registration-form-target="rulesSummary"
+           aria-live="polite">
+          Please satisfy password requirements.
+        </p>
+        <ul class="password-rules">
+          <li class="password-rule pending" data-registration-form-target="minLengthRule">
+            At least 8 characters
+          </li>
+          <li class="password-rule pending" data-registration-form-target="confirmationRule">
+            Matches confirmation password
+          </li>
+        </ul>
       </div>
 
       <div class="form-group">

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -15,21 +15,90 @@
       </div>
     <% end %>
 
-    <%= form_with model: @user, url: signup_path, method: :post, data: { turbo: false } do |f| %>
+    <% email_local_part_value = params.dig(:user, :email_local_part).presence || @user.email.to_s.split("@", 2).first %>
+
+    <%= form_with model: @user,
+                  url: signup_path,
+                  method: :post,
+                  data: {
+                    turbo: false,
+                    controller: "domain-lock-email registration-form",
+                    domain_lock_email_domain_value: User::CUHK_EMAIL_DOMAIN
+                  } do |f| %>
       <div class="form-group">
-        <%= f.label :email, "CUHK Email" %>
-        <%= f.email_field :email, required: true, autofocus: true,
-            placeholder: "yourname@link.cuhk.edu.hk" %>
+        <%= label_tag "user_email_local_part", "CUHK Email" %>
+        <div class="domain-email-input">
+          <%= text_field_tag "user[email_local_part]",
+                             email_local_part_value,
+                             id: "user_email_local_part",
+                             required: true,
+                             autofocus: true,
+                             autocomplete: "username",
+                             pattern: "[^@\\s]+",
+                             title: "Enter your CUHK account local part only.",
+                             placeholder: "e.g. 1155209296",
+                             data: {
+                               domain_lock_email_target: "localPart",
+                               action: "input->domain-lock-email#sanitize input->domain-lock-email#updatePreview"
+                             } %>
+          <span class="domain-email-suffix">@link.cuhk.edu.hk</span>
+        </div>
+        <p class="form-hint">
+          Enter only your student ID/local part.
+          Full email: <strong data-domain-lock-email-target="fullPreview"></strong>
+        </p>
       </div>
 
       <div class="form-group">
-        <%= f.label :password %>
-        <%= f.password_field :password, required: true, placeholder: "Create a password" %>
+        <div class="form-inline-actions">
+          <%= f.label :password %>
+          <button type="button"
+                  class="btn-secondary btn-sm"
+                  data-action="registration-form#generatePassword">
+            Generate strong password
+          </button>
+        </div>
+        <%= f.password_field :password,
+                             required: true,
+                             placeholder: "Create a password",
+                             autocomplete: "new-password",
+                             data: {
+                               registration_form_target: "password",
+                               action: "input->registration-form#updateRules"
+                             } %>
+        <ul class="password-rules">
+          <li class="password-rule pending" data-registration-form-target="minLengthRule">
+            At least 8 characters
+          </li>
+          <li class="password-rule pending" data-registration-form-target="confirmationRule">
+            Matches confirmation password
+          </li>
+        </ul>
+        <p class="password-rules-summary" data-registration-form-target="rulesSummary">
+          Please satisfy all password requirements.
+        </p>
+        <div class="generated-password-panel" data-registration-form-target="generatedPanel" hidden>
+          <span>Generated password:</span>
+          <code data-registration-form-target="generatedPassword"></code>
+          <button type="button"
+                  class="btn-secondary btn-sm"
+                  data-action="registration-form#copyGeneratedPassword">
+            Copy
+          </button>
+          <span class="copy-feedback" data-registration-form-target="copyFeedback"></span>
+        </div>
       </div>
 
       <div class="form-group">
         <%= f.label :password_confirmation, "Confirm Password" %>
-        <%= f.password_field :password_confirmation, required: true, placeholder: "Confirm your password" %>
+        <%= f.password_field :password_confirmation,
+                             required: true,
+                             placeholder: "Confirm your password",
+                             autocomplete: "new-password",
+                             data: {
+                               registration_form_target: "passwordConfirmation",
+                               action: "input->registration-form#updateRules"
+                             } %>
       </div>
 
       <div class="form-group">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,10 +9,36 @@
       <div class="alert"><%= flash[:alert] %></div>
     <% end %>
 
-    <%= form_with url: login_path, method: :post, data: { turbo: false } do |f| %>
+    <% login_local_part_value = params[:email_local_part].presence || params[:email].to_s.split("@", 2).first %>
+
+    <%= form_with url: login_path,
+                  method: :post,
+                  data: {
+                    turbo: false,
+                    controller: "domain-lock-email",
+                    domain_lock_email_domain_value: User::CUHK_EMAIL_DOMAIN
+                  } do |f| %>
       <div class="form-group">
-        <%= f.label :email, "Email" %>
-        <%= f.email_field :email, required: true, autofocus: true, placeholder: "you@link.cuhk.edu.hk" %>
+        <%= f.label :email_local_part, "Email" %>
+        <div class="domain-email-input">
+          <%= f.text_field :email_local_part,
+                           value: login_local_part_value,
+                           required: true,
+                           autofocus: true,
+                           autocomplete: "username",
+                           pattern: "[^@\\s]+",
+                           title: "Enter your CUHK account local part only.",
+                           placeholder: "e.g. 1155209296",
+                           data: {
+                             domain_lock_email_target: "localPart",
+                             action: "input->domain-lock-email#sanitize input->domain-lock-email#updatePreview"
+                           } %>
+          <span class="domain-email-suffix">@link.cuhk.edu.hk</span>
+        </div>
+        <p class="form-hint">
+          Sign in with your student ID/local part.
+          Full email: <strong data-domain-lock-email-target="fullPreview"></strong>
+        </p>
       </div>
 
       <div class="form-group">

--- a/db/migrate/20260409192339_add_active_session_token_to_users.rb
+++ b/db/migrate/20260409192339_add_active_session_token_to_users.rb
@@ -1,0 +1,6 @@
+class AddActiveSessionTokenToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :active_session_token, :string
+    add_index :users, :active_session_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_09_180008) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_09_192339) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -46,7 +46,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_09_180008) do
     t.date "end_date"
     t.datetime "end_time"
     t.bigint "equipment_id"
-    t.integer "quantity"
+    t.integer "quantity", default: 0
     t.text "rejection_reason"
     t.date "start_date"
     t.datetime "start_time"
@@ -104,6 +104,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_09_180008) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.string "active_session_token"
+    t.string "college_scope_slug"
     t.datetime "created_at", null: false
     t.string "email", null: false
     t.boolean "is_root_account", default: false, null: false
@@ -112,6 +114,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_09_180008) do
     t.integer "society_id"
     t.integer "tenant_id"
     t.datetime "updated_at", null: false
+    t.index ["active_session_token"], name: "index_users_on_active_session_token", unique: true
+    t.index ["college_scope_slug"], name: "index_users_on_college_scope_slug"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["society_id"], name: "index_users_on_society_id"
     t.index ["tenant_id"], name: "index_users_on_tenant_id"

--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -18,6 +18,14 @@ Feature: User Authentication
     Then I should see "Dashboard"
     And I should see "Admin"
 
+  Scenario: Successful login with local-part only
+    Given I am on the login page
+    When I fill in "Email" with "admin"
+    And I fill in "Password" with "Password1!"
+    And I press "Sign In"
+    Then I should see "Dashboard"
+    And I should see "Admin"
+
   Scenario: Successful login as staff
     Given I am on the login page
     When I fill in "Email" with "staff@link.cuhk.edu.hk"

--- a/features/registration.feature
+++ b/features/registration.feature
@@ -28,7 +28,7 @@ Feature: Student registration
 
   Scenario: Student completes signup after email code verification
     When I am on the registration page
-    And I fill in "CUHK Email" with "verified@link.cuhk.edu.hk"
+    And I fill in "CUHK Email" with "verified"
     And I fill in "Password" with "Password1!"
     And I fill in "Confirm Password" with "Password1!"
     And I select "Chung Chi College" from "College"
@@ -40,7 +40,7 @@ Feature: Student registration
 
   Scenario: Invalid verification code blocks account creation
     When I am on the registration page
-    And I fill in "CUHK Email" with "invalidcode@link.cuhk.edu.hk"
+    And I fill in "CUHK Email" with "invalidcode"
     And I fill in "Password" with "Password1!"
     And I fill in "Confirm Password" with "Password1!"
     And I select "New Asia College" from "College"

--- a/features/step_definitions/approval_workflow_steps.rb
+++ b/features/step_definitions/approval_workflow_steps.rb
@@ -176,7 +176,7 @@ When("the staff approves my booking for {string}") do |venue_name|
 
   Capybara.using_session("staff_session") do
     visit login_path
-    fill_in "Email", with: "staff@link.cuhk.edu.hk"
+    fill_in "Email", with: "staff"
     fill_in "Password", with: "password1"
     click_button "Sign In"
 
@@ -207,6 +207,11 @@ Then("I should see the status update to {string} without refreshing the page") d
     visit my_bookings_path
   end
 
+  unless page.has_css?("[data-booking-id='#{booking.id}']", text: status, wait: 5)
+    sign_in_for_cucumber!("student@link.cuhk.edu.hk")
+    visit my_bookings_path
+  end
+
   expect(page).to have_css("[data-booking-id='#{booking.id}']", text: status, wait: 10)
 end
 
@@ -230,4 +235,17 @@ def wait_for_booking_status!(booking, expected_status, timeout: 10)
 
     sleep 0.1
   end
+end
+
+def sign_in_for_cucumber!(email)
+  user = User.find_by!(email: email)
+  password = ["password", "password1", "Password1!"].find { |value| user.authenticate(value) }
+  raise "No valid password found for #{email}" unless password
+
+  user.update!(active_session_token: nil)
+
+  visit login_path
+  fill_in "Email", with: email.to_s.split("@", 2).first
+  fill_in "Password", with: password
+  click_button "Sign In"
 end

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -10,6 +10,7 @@ Given('the following users exist:') do |table|
     user.password_confirmation = hash['password']
     user.role = role
     user.tenant = tenant
+    user.active_session_token = nil
     user.save!
   end
 end
@@ -36,8 +37,11 @@ Then('I should see {string} only once') do |text|
 end
 
 Given('I am logged in as {string} with password {string}') do |email, password|
+  user = User.find_by(email: email)
+  user&.update!(active_session_token: nil)
+
   visit login_path
-  fill_in 'Email', with: email
+  fill_in 'Email', with: email.to_s.split("@", 2).first
   fill_in 'Password', with: password
   click_button 'Sign In'
 end

--- a/features/step_definitions/tenant_isolation_steps.rb
+++ b/features/step_definitions/tenant_isolation_steps.rb
@@ -18,7 +18,7 @@ Given('I am logged in as a {string} of {string}') do |role, tenant_name|
   )
 
   visit '/login'
-  fill_in 'Email', with: @current_user.email
+  fill_in 'Email', with: @current_user.email.to_s.split("@", 2).first
   fill_in 'Password', with: 'Password1!'
   click_button 'Sign In'
 end

--- a/features/step_definitions/venue_booking_steps.rb
+++ b/features/step_definitions/venue_booking_steps.rb
@@ -13,11 +13,12 @@ end
 
 Given('I am logged in as {string}') do |email|
   user = User.find_by!(email: email)
+  user.update!(active_session_token: nil)
   password = ["password", "password1", "Password1!"].find { |value| user.authenticate(value) }
   raise "No valid password found for #{email}" unless password
 
   visit login_path
-  fill_in 'Email', with: email
+  fill_in 'Email', with: email.to_s.split("@", 2).first
   fill_in 'Password', with: password
   click_button 'Sign In'
 end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'Registrations', type: :request do
       expect(response.body).to include('Chung Chi College')
       expect(response.body).to include('New Asia College')
       expect(response.body).not_to include('University')
+      expect(response.body).to include('@link.cuhk.edu.hk')
+      expect(response.body).to include('Generate strong password')
     end
   end
 
@@ -64,6 +66,19 @@ RSpec.describe 'Registrations', type: :request do
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include('Tenant must be one of the eligible CUHK colleges')
+    end
+
+    it 'accepts email local part input and appends CUHK domain' do
+      local_part_params = valid_params.deep_merge(user: {
+        email: nil,
+        email_local_part: '1155209296'
+      })
+
+      post signup_path, params: local_part_params
+
+      expect(response).to redirect_to(signup_verify_path)
+      expect(flash[:notice]).to include('1155209296@link.cuhk.edu.hk')
+      expect(SignupVerificationCode.find_by(email: '1155209296@link.cuhk.edu.hk')).to be_present
     end
   end
 

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Sessions', type: :request do
       get login_path
       expect(response).to have_http_status(:ok)
       expect(response.body).to include('Sign In')
+      expect(response.body).to include('@link.cuhk.edu.hk')
     end
   end
 
@@ -18,6 +19,11 @@ RSpec.describe 'Sessions', type: :request do
       expect(user.reload.active_session_token).to be_present
       follow_redirect!
       expect(response.body).to include('Dashboard')
+    end
+
+    it 'logs in with local-part identifier' do
+      post login_path, params: { email_local_part: user.email.split('@').first, password: 'Password1!' }
+      expect(response).to redirect_to(dashboard_path)
     end
 
     it 'blocks concurrent login attempts for the same account' do

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -15,8 +15,28 @@ RSpec.describe 'Sessions', type: :request do
     it 'logs in with valid credentials and redirects to dashboard' do
       post login_path, params: { email: user.email, password: 'Password1!' }
       expect(response).to redirect_to(dashboard_path)
+      expect(user.reload.active_session_token).to be_present
       follow_redirect!
       expect(response.body).to include('Dashboard')
+    end
+
+    it 'blocks concurrent login attempts for the same account' do
+      browser_one = ActionDispatch::Integration::Session.new(Rails.application)
+      browser_two = ActionDispatch::Integration::Session.new(Rails.application)
+
+      browser_one.post login_path, params: { email: user.email, password: 'Password1!' }
+      expect(browser_one.status).to eq(302)
+      expect(browser_one.response.headers['Location']).to end_with(dashboard_path)
+      existing_token = user.reload.active_session_token
+      expect(existing_token).to be_present
+
+      browser_two.post login_path, params: { email: user.email, password: 'Password1!' }
+      expect(browser_two.status).to eq(409)
+      expect(browser_two.response.body).to include('already logged in on another device')
+      expect(user.reload.active_session_token).to eq(existing_token)
+
+      browser_one.get dashboard_path
+      expect(browser_one.status).to eq(200)
     end
 
     it 'rejects invalid credentials' do
@@ -35,8 +55,19 @@ RSpec.describe 'Sessions', type: :request do
   describe 'DELETE /logout' do
     it 'logs out the user and redirects to login' do
       log_in_as(user)
+      expect(user.reload.active_session_token).to be_present
+
       delete logout_path
       expect(response).to redirect_to(login_path)
+      expect(user.reload.active_session_token).to be_nil
+    end
+
+    it 'allows login again after logout releases lock' do
+      log_in_as(user)
+      delete logout_path
+
+      post login_path, params: { email: user.email, password: 'Password1!' }
+      expect(response).to redirect_to(dashboard_path)
     end
   end
 
@@ -50,6 +81,14 @@ RSpec.describe 'Sessions', type: :request do
       log_in_as(user)
       get dashboard_path
       expect(response).to have_http_status(:ok)
+    end
+
+    it 'invalidates stale sessions after session token changes' do
+      log_in_as(user)
+      user.update!(active_session_token: SecureRandom.hex(32))
+
+      get dashboard_path
+      expect(response).to redirect_to(login_path)
     end
 
     it 'hides Booking link for society member dashboard' do


### PR DESCRIPTION
## Summary
This PR now includes both the original **#63** single-session enforcement and the stacked **#77** authentication UX improvements.

### #63 — Single active session per account
- add `users.active_session_token` persistence + unique index
- block concurrent second login attempts in `SessionsController#create`
- release token on logout and invalidate stale sessions in `ApplicationController#current_user`
- keep signup success path aligned with the same session-token contract

### #77 — Registration/Login UX improvements
- add CUHK domain-locked auth input flow (local-part input + fixed `@link.cuhk.edu.hk`) for **signup and login**
- canonicalize local-part/full-email input server-side via `User.canonicalize_cuhk_email`
- add registration password UX: live requirement checklist, random strong password generation, and one-click copy
- align Cucumber auth steps with local-part login input so JS browser validation and end-to-end flow stay reliable

## Commit breakdown
1. `e803dc8` — Add CUHK domain-locked login input flow
2. `c345138` — Improve signup UX with guided password creation
3. `004f183` — Align specs and cucumber auth steps with local-part emails

## Validation
- `bin/rubocop`
- `bundle exec rspec`
- `bundle exec cucumber`

Closes #63
Closes #77