### PR TITLE
Implement automatic rejection of expired pending venue bookings and a…

### DIFF
--- a/app/jobs/expire_pending_venue_bookings_job.rb
+++ b/app/jobs/expire_pending_venue_bookings_job.rb
@@ -1,0 +1,7 @@
+class ExpirePendingVenueBookingsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    VenueBooking.reject_expired_pending!
+  end
+end

--- a/app/models/venue_booking.rb
+++ b/app/models/venue_booking.rb
@@ -1,6 +1,16 @@
 class VenueBooking < Booking
+  EXPIRED_PENDING_REJECTION_REASON = "Booking date has passed".freeze
+
   def self.model_name
     Booking.model_name
+  end
+
+  def self.reject_expired_pending!(at: Time.current)
+    pending
+      .where("end_time < ?", at)
+      .find_each do |booking|
+        booking.reject!(EXPIRED_PENDING_REJECTION_REASON)
+      end
   end
 
   validates :venue, presence: true
@@ -51,7 +61,7 @@ class VenueBooking < Booking
   end
 
   def advance_booking_limit
-    return unless start_time.present?
+    return unless start_time.present? && pending?
 
     # Booking must be at least 5 days in advance
     if start_time.to_date < 5.days.from_now.to_date

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,6 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  expire_pending_venue_bookings:
+    command: "ExpirePendingVenueBookingsJob.perform_now"
+    schedule: every hour at minute 49

--- a/features/approval_workflow.feature
+++ b/features/approval_workflow.feature
@@ -58,6 +58,16 @@ Feature: Booking Approval Workflow
     And I click "Cancel Booking"
     Then the booking for "Room 101" on a date 5 days in the future should remain "Cancelled"
 
+  Scenario: Pending booking is automatically rejected after its booking date passes
+    Given I am logged in as "staff@link.cuhk.edu.hk"
+    And there is a venue "Expired Room"
+    And "student@link.cuhk.edu.hk" has a pending booking for "Expired Room" 1 days in the past
+    When I run the expired booking rejection job
+    Then the booking status should be "Rejected"
+    And the booking rejection reason should be "Booking date has passed"
+    When I visit the approval dashboard
+    Then I should not see the pending booking for "Expired Room"
+
   @javascript
   Scenario: Student is notified in real-time when booking is approved
     Given I am logged in as "student@link.cuhk.edu.hk"

--- a/features/step_definitions/approval_workflow_steps.rb
+++ b/features/step_definitions/approval_workflow_steps.rb
@@ -37,6 +37,32 @@ Given("{string} has a pending booking for {string} on a date {int} days in the f
   )
 end
 
+Given("{string} has a pending booking for {string} {int} days in the past") do |email, venue_name, days|
+  user = User.find_by!(email: email)
+  venue = Venue.find_by!(name: venue_name)
+  date = (Date.current - days.days).strftime("%Y-%m-%d")
+
+  future_date = (Date.current + 5.days).strftime("%Y-%m-%d")
+  booking = create(
+    :booking,
+    user: user,
+    venue: venue,
+    start_time: Time.zone.parse("#{future_date} 13:00"),
+    end_time: Time.zone.parse("#{future_date} 15:00"),
+    status: :pending
+  )
+
+  booking.update_columns(
+    start_time: Time.zone.parse("#{date} 10:00"),
+    end_time: Time.zone.parse("#{date} 12:00"),
+    status: Booking.statuses[:pending],
+    rejection_reason: nil,
+    updated_at: Time.current
+  )
+
+  @current_booking = booking
+end
+
 Given("tenant {string} uses two-step approval") do |tenant_name|
   tenant = Tenant.find_by!(name: tenant_name)
   tenant.update!(approval_mode: :two_step)
@@ -73,10 +99,19 @@ When("I approve the booking for {string} on a date {int} days in the future") do
   step "I approve the booking for \"#{venue_name}\" on \"#{date}\""
 end
 
+When("I run the expired booking rejection job") do
+  ExpirePendingVenueBookingsJob.perform_now
+end
+
 Then("the booking status should be {string}") do |status|
   booking = @current_booking || Booking.last
   normalized_status = status.downcase.tr(" ", "_")
   expect(booking.reload.status).to eq(normalized_status)
+end
+
+Then("the booking rejection reason should be {string}") do |reason|
+  booking = @current_booking || Booking.last
+  expect(booking.reload.rejection_reason).to eq(reason)
 end
 
 Then("{string} should receive a confirmation email") do |email|
@@ -215,6 +250,10 @@ Then("I should not be on the approval dashboard page") do
 end
 
 Then("I should not see the booking for {string}") do |venue_name|
+  expect(page).not_to have_content(venue_name)
+end
+
+Then("I should not see the pending booking for {string}") do |venue_name|
   expect(page).not_to have_content(venue_name)
 end
 

--- a/spec/jobs/expire_pending_venue_bookings_job_spec.rb
+++ b/spec/jobs/expire_pending_venue_bookings_job_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe ExpirePendingVenueBookingsJob, type: :job do
+  let(:tenant) { create(:tenant, name: 'University', slug: 'university') }
+  let(:user) { create(:user, tenant: tenant) }
+  let(:venue) { create(:venue, tenant: tenant, department: tenant.name) }
+
+  it 'rejects pending venue bookings whose booking date has passed' do
+    expired_booking = create(
+      :booking,
+      user: user,
+      venue: venue,
+      start_time: Time.zone.parse("#{5.days.from_now.to_date} 10:00:00"),
+      end_time: Time.zone.parse("#{5.days.from_now.to_date} 12:00:00"),
+      status: :pending
+    )
+    expired_booking.update_columns(
+      start_time: Time.zone.parse("#{1.day.ago.to_date} 10:00:00"),
+      end_time: Time.zone.parse("#{1.day.ago.to_date} 12:00:00"),
+      status: Booking.statuses[:pending],
+      rejection_reason: nil,
+      updated_at: Time.current
+    )
+    future_booking = create(
+      :booking,
+      user: user,
+      venue: venue,
+      start_time: Time.zone.parse("#{5.days.from_now.to_date} 10:00:00"),
+      end_time: Time.zone.parse("#{5.days.from_now.to_date} 12:00:00"),
+      status: :pending
+    )
+
+    described_class.perform_now
+
+    expect(expired_booking.reload.status).to eq('rejected')
+    expect(expired_booking.rejection_reason).to eq('Booking date has passed')
+    expect(future_booking.reload.status).to eq('pending')
+  end
+end

--- a/spec/models/venue_booking_spec.rb
+++ b/spec/models/venue_booking_spec.rb
@@ -29,4 +29,28 @@ RSpec.describe VenueBooking, type: :model do
     expect(booking).not_to be_valid
     expect(booking.errors[:base]).to include('must be between 08:00 and 22:00')
   end
+
+  it 'rejects expired pending venue bookings' do
+    expired_booking = create(
+      :booking,
+      user: user,
+      venue: venue,
+      start_time: Time.zone.parse('2026-04-15 10:00:00'),
+      end_time: Time.zone.parse('2026-04-15 12:00:00'),
+      status: :pending
+    )
+
+    expired_booking.update_columns(
+      start_time: Time.zone.parse('2026-04-09 10:00:00'),
+      end_time: Time.zone.parse('2026-04-09 12:00:00'),
+      status: Booking.statuses[:pending],
+      rejection_reason: nil,
+      updated_at: Time.current
+    )
+
+    described_class.reject_expired_pending!(at: Time.zone.parse('2026-04-10 00:00:00'))
+
+    expect(expired_booking.reload.status).to eq('rejected')
+    expect(expired_booking.rejection_reason).to eq('Booking date has passed')
+  end
 end


### PR DESCRIPTION
This pull request introduces an automated process to reject pending venue bookings whose booking date has already passed. It adds a scheduled job to periodically check for such expired bookings and mark them as rejected with a clear reason. The changes also include updates to the test suite and feature specs to ensure this new behavior is properly covered and validated.

**Automated Expired Booking Rejection**

- Added a new job `ExpirePendingVenueBookingsJob` that calls a method to reject all pending venue bookings whose `end_time` is in the past.
- Implemented the class method `VenueBooking.reject_expired_pending!`, which finds and rejects all pending bookings with an `end_time` before the current time, setting the rejection reason to "Booking date has passed".
- Scheduled the job to run hourly via the recurring jobs configuration (`config/recurring.yml`).

**Feature and Step Definition Updates**

- Added a feature scenario to verify that pending bookings are automatically rejected after their booking date passes, and that such bookings are removed from the approval dashboard.
- Added step definitions to support the new feature scenario, including steps to create expired bookings, run the job, and check booking status and rejection reasons. [[1]](diffhunk://#diff-eb6f359afdd0cb9e9c67b63cb7d3069ba9df55eb1bd4199d0e68bc46a705d28dR40-R65) [[2]](diffhunk://#diff-eb6f359afdd0cb9e9c67b63cb7d3069ba9df55eb1bd4199d0e68bc46a705d28dR102-R116) [[3]](diffhunk://#diff-eb6f359afdd0cb9e9c67b63cb7d3069ba9df55eb1bd4199d0e68bc46a705d28dR256-R259)

**Test Coverage**

- Added a job spec (`expire_pending_venue_bookings_job_spec.rb`) to ensure the job correctly rejects only expired pending bookings and leaves future bookings untouched.
- Added a model spec to verify that `VenueBooking.reject_expired_pending!` works as expected for expired bookings.

**Booking Validation Adjustment**

- Updated the `advance_booking_limit` validation to only apply to pending bookings, preventing unnecessary validation for rejected or approved bookings.