### PR TITLE
Fix realtime booking status styling and rejection reason updates

### DIFF
--- a/app/javascript/controllers/booking_status_controller.js
+++ b/app/javascript/controllers/booking_status_controller.js
@@ -34,18 +34,54 @@ export default class extends Controller {
             return
         }
 
+        const normalizedStatus = (data.status || "").toString().toLowerCase()
+        const label = data.status_label || this.humanizeStatus(normalizedStatus)
+
         const statusNode = this.element.querySelector(
-            `[data-booking-id="${data.booking_id}"]`
+            `[data-booking-status-id="${data.booking_id}"], [data-booking-id="${data.booking_id}"]`
         )
         if (statusNode) {
-            const normalizedStatus = (data.status || "").toString().toLowerCase()
-            const label = data.status_label || this.humanizeStatus(normalizedStatus)
+            statusNode.innerHTML = ""
 
-            statusNode.textContent = label
+            const badgeNode = document.createElement("span")
+            badgeNode.className = `badge ${this.badgeClass(normalizedStatus)}`
+            badgeNode.textContent = label
+            statusNode.appendChild(badgeNode)
+
             if (normalizedStatus) {
                 statusNode.dataset.status = normalizedStatus
             }
         }
+
+        const rejectionReasonNode = this.element.querySelector(
+            `[data-booking-rejection-reason-id="${data.booking_id}"]`
+        )
+        if (rejectionReasonNode) {
+            rejectionReasonNode.textContent = this.rejectionReason(normalizedStatus, data.rejection_reason)
+        }
+    }
+
+    badgeClass(status) {
+        const mapping = {
+            pending: "badge-pending",
+            approved: "badge-approved",
+            rejected: "badge-rejected",
+            cancelled: "badge-cancelled",
+            under_review: "badge-under-review",
+            borrowed: "badge-borrowed",
+            returned: "badge-returned"
+        }
+
+        return mapping[status] || "badge-pending"
+    }
+
+    rejectionReason(status, reason) {
+        if (status !== "rejected") {
+            return ""
+        }
+
+        const normalizedReason = (reason || "").toString().trim()
+        return normalizedReason.length > 0 ? normalizedReason : "No reason provided"
     }
 
     humanizeStatus(status) {

--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -97,7 +97,12 @@ class Booking < ApplicationRecord
   def broadcast_status_change
     ActionCable.server.broadcast(
       "booking_status_user_#{user_id}",
-      { booking_id: id, status: status, status_label: status.titleize }
+      {
+        booking_id: id,
+        status: status,
+        status_label: status.titleize,
+        rejection_reason: rejected? ? rejection_reason : nil
+      }
     )
   end
 

--- a/app/views/bookings/my.html.erb
+++ b/app/views/bookings/my.html.erb
@@ -34,8 +34,8 @@
                 <td><strong><%= booking.venue.name %></strong></td>
                 <td><%= booking.start_time %></td>
                 <td><%= booking.end_time %></td>
-                <td data-booking-id="<%= booking.id %>" data-status="<%= booking.status %>"><%= status_badge(booking.status) %></td>
-                <td class="text-muted text-sm"><%= booking.rejected? ? (booking.rejection_reason.presence || "No reason provided") : "" %></td>
+                <td data-booking-status-id="<%= booking.id %>" data-booking-id="<%= booking.id %>" data-status="<%= booking.status %>"><%= status_badge(booking.status) %></td>
+                <td data-booking-rejection-reason-id="<%= booking.id %>" class="text-muted text-sm"><%= booking.rejected? ? (booking.rejection_reason.presence || "No reason provided") : "" %></td>
                 <td>
                   <div class="btn-group">
                     <%= link_to "View", booking_path(booking), class: "btn btn-outline btn-sm" %>
@@ -73,8 +73,8 @@
                 <td><%= booking.quantity || "-" %></td>
                 <td><%= booking.start_date || booking.start_time %></td>
                 <td><%= booking.end_date || booking.end_time %></td>
-                <td data-booking-id="<%= booking.id %>" data-status="<%= booking.status %>"><%= status_badge(booking.status) %></td>
-                <td class="text-muted text-sm"><%= booking.rejected? ? (booking.rejection_reason.presence || "No reason provided") : "" %></td>
+                <td data-booking-status-id="<%= booking.id %>" data-booking-id="<%= booking.id %>" data-status="<%= booking.status %>"><%= status_badge(booking.status) %></td>
+                <td data-booking-rejection-reason-id="<%= booking.id %>" class="text-muted text-sm"><%= booking.rejected? ? (booking.rejection_reason.presence || "No reason provided") : "" %></td>
                 <td>
                   <div class="btn-group">
                     <%= link_to "View", booking_path(booking), class: "btn btn-outline btn-sm" %>

--- a/spec/models/booking_spec.rb
+++ b/spec/models/booking_spec.rb
@@ -190,10 +190,26 @@ RSpec.describe Booking, type: :model do
 
       expect(ActionCable.server).to receive(:broadcast).with(
         "booking_status_user_#{booking.user_id}",
-        hash_including(booking_id: booking.id, status: 'approved', status_label: 'Approved')
+        hash_including(booking_id: booking.id, status: 'approved', status_label: 'Approved', rejection_reason: nil)
       )
 
       booking.update!(status: :approved)
+    end
+
+    it 'broadcasts rejection reason when status changes to rejected' do
+      booking = create(:booking, status: :pending)
+
+      expect(ActionCable.server).to receive(:broadcast).with(
+        "booking_status_user_#{booking.user_id}",
+        hash_including(
+          booking_id: booking.id,
+          status: 'rejected',
+          status_label: 'Rejected',
+          rejection_reason: 'Capacity issue'
+        )
+      )
+
+      booking.reject!('Capacity issue')
     end
 
     it 'does not broadcast when status is unchanged' do


### PR DESCRIPTION
## Summary
- include rejection_reason in booking status ActionCable payloads
- update the booking status Stimulus controller to render proper badge markup/classes on live updates
- update My Bookings row targets so realtime updates also refresh the rejection reason cell without reload
- add model spec coverage for rejected payload broadcasts

## Validation
- bin/rubocop app/models/booking.rb spec/models/booking_spec.rb
- bundle exec rspec spec/models/booking_spec.rb:188 spec/models/booking_spec.rb:199 spec/models/booking_spec.rb:215
- RAILS_ENV=test bin/rails db:drop db:create db:schema:load && bundle exec rspec && bundle exec cucumber features/approval_workflow.feature:72