### PR TITLE
Add OTP password reset flow with secure unknown-account handling

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,156 @@
+class PasswordResetsController < ApplicationController
+  PENDING_PASSWORD_RESET_SESSION_KEY = :pending_password_reset
+
+  skip_before_action :require_authentication, only: [:new, :create, :verify, :update, :resend_code]
+  before_action :require_pending_password_reset, only: [:verify, :update, :resend_code]
+
+  def new
+  end
+
+  def create
+    @pending_email = User.canonicalize_cuhk_email(email_input)
+    user = User.find_by(email: @pending_email)
+
+    unless user
+      redirect_to password_reset_path, notice: "If an eligible account exists for this email, a verification code has been sent."
+      return
+    end
+
+    unless eligible_for_password_reset?(user)
+      flash.now[:alert] = "Password reset is only available for student and non-root staff accounts."
+      render :new, status: :unprocessable_content
+      return
+    end
+
+    session[PENDING_PASSWORD_RESET_SESSION_KEY] = { "email" => @pending_email }
+    issue_result = PasswordResetService.issue_initial_code(email: @pending_email)
+
+    case issue_result.status
+    when :sent
+      redirect_to password_reset_verify_path, notice: "Verification code sent to #{@pending_email}."
+    when :cooldown
+      redirect_to password_reset_verify_path, alert: "A code was sent recently. Please wait #{issue_result.cooldown_seconds} second(s) before requesting another one."
+    when :delivery_unavailable
+      clear_pending_password_reset
+      flash.now[:alert] = "Verification email is unavailable right now. Please try again later."
+      render :new, status: :service_unavailable
+    when :delivery_failed
+      clear_pending_password_reset
+      flash.now[:alert] = "Verification email could not be delivered. Please try again."
+      render :new, status: :unprocessable_content
+    else
+      clear_pending_password_reset
+      flash.now[:alert] = "Verification code could not be sent. Please try again."
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def verify
+    @pending_email = pending_password_reset_data.fetch("email")
+  end
+
+  def update
+    @pending_email = pending_password_reset_data.fetch("email")
+    verification_result = PasswordResetService.verify_code(
+      email: @pending_email,
+      submitted_code: params[:verification_code]
+    )
+
+    unless verification_result.success?
+      flash.now[:alert] = verification_error_message(verification_result)
+      render :verify, status: :unprocessable_content
+      return
+    end
+
+    user = User.find_by(email: @pending_email)
+    unless eligible_for_password_reset?(user)
+      clear_pending_password_reset
+      redirect_to password_reset_path, alert: "Password reset session expired. Please start again."
+      return
+    end
+
+    if password_reset_params[:password].blank?
+      flash.now[:alert] = "Password can't be blank."
+      render :verify, status: :unprocessable_content
+      return
+    end
+
+    if user.update(password_reset_params.merge(active_session_token: nil))
+      PasswordResetService.consume_code!(email: @pending_email)
+      clear_pending_password_reset
+      reset_session
+      redirect_to login_path, notice: "Password reset successfully. Please sign in with your new password."
+    else
+      flash.now[:alert] = user.errors.full_messages.to_sentence.presence || "Password could not be reset."
+      render :verify, status: :unprocessable_content
+    end
+  end
+
+  def resend_code
+    issue_result = PasswordResetService.resend_code(email: pending_password_reset_data.fetch("email"))
+
+    case issue_result.status
+    when :sent
+      redirect_to password_reset_verify_path, notice: "A new verification code has been sent."
+    when :cooldown
+      redirect_to password_reset_verify_path, alert: "Please wait #{issue_result.cooldown_seconds} second(s) before requesting another code."
+    when :resend_limit
+      redirect_to password_reset_verify_path, alert: "Resend limit reached. Use the latest code in your inbox."
+    when :delivery_unavailable
+      redirect_to password_reset_verify_path, alert: "Verification email is unavailable right now. Please try again later."
+    when :delivery_failed
+      redirect_to password_reset_verify_path, alert: "Verification email could not be delivered. Please try again."
+    else
+      clear_pending_password_reset
+      redirect_to password_reset_path, alert: "Password reset session expired. Please start again."
+    end
+  end
+
+  private
+
+  def email_input
+    params[:email_local_part].presence || params[:email]
+  end
+
+  def pending_password_reset_data
+    data = session[PENDING_PASSWORD_RESET_SESSION_KEY]
+    data.is_a?(Hash) ? data.with_indifferent_access : nil
+  end
+
+  def require_pending_password_reset
+    return if pending_password_reset_data.present?
+
+    redirect_to password_reset_path, alert: "Please request a verification code first."
+  end
+
+  def clear_pending_password_reset
+    session.delete(PENDING_PASSWORD_RESET_SESSION_KEY)
+  end
+
+  def password_reset_params
+    params.permit(:password, :password_confirmation)
+  end
+
+  def verification_error_message(result)
+    case result.status
+    when :blank
+      "Verification code cannot be blank."
+    when :missing
+      "Verification code not found. Please request a new code."
+    when :used
+      "This verification code has already been used."
+    when :expired
+      "Verification code has expired. Please request a new code."
+    when :attempt_limit
+      "Too many invalid attempts. Please request a new code."
+    else
+      "Invalid verification code. Attempts remaining: #{result.remaining_attempts}."
+    end
+  end
+
+  def eligible_for_password_reset?(user)
+    return false unless user
+
+    user.student? || (user.staff? && !user.root_account?)
+  end
+end

--- a/app/mailers/password_reset_mailer.rb
+++ b/app/mailers/password_reset_mailer.rb
@@ -1,0 +1,8 @@
+class PasswordResetMailer < ApplicationMailer
+  def verification_code
+    @email = params.fetch(:email)
+    @code = params.fetch(:code)
+
+    mail to: @email, subject: "Your CUHK password reset code"
+  end
+end

--- a/app/models/password_reset_code.rb
+++ b/app/models/password_reset_code.rb
@@ -1,0 +1,36 @@
+class PasswordResetCode < ApplicationRecord
+  MAX_ATTEMPTS = 5
+  MAX_RESENDS = 3
+  CODE_TTL = 10.minutes
+  RESEND_COOLDOWN = 60.seconds
+
+  normalizes :email, with: ->(email) { email.to_s.strip.downcase }
+
+  validates :email, presence: true, format: { with: User::CUHK_EMAIL_REGEX, message: "must be a valid @link.cuhk.edu.hk address" }
+  validates :code_digest, presence: true
+  validates :expires_at, presence: true
+  validates :last_sent_at, presence: true
+  validates :attempt_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :resend_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  scope :active, -> { where(used_at: nil).where("expires_at > ?", Time.current) }
+
+  def expired?(at_time = Time.current)
+    expires_at <= at_time
+  end
+
+  def consumed?
+    used_at.present?
+  end
+
+  def attempts_exhausted?
+    attempt_count >= MAX_ATTEMPTS
+  end
+
+  def resend_cooldown_seconds(at_time = Time.current)
+    return 0 unless last_sent_at.present?
+
+    remaining = (last_sent_at + RESEND_COOLDOWN - at_time).ceil
+    remaining.positive? ? remaining : 0
+  end
+end

--- a/app/services/password_reset_service.rb
+++ b/app/services/password_reset_service.rb
@@ -1,0 +1,100 @@
+class PasswordResetService
+  CODE_FORMAT = "%06d"
+
+  IssueResult = Struct.new(:status, :cooldown_seconds, keyword_init: true) do
+    def sent?
+      status == :sent
+    end
+  end
+
+  VerifyResult = Struct.new(:status, :remaining_attempts, keyword_init: true) do
+    def success?
+      status == :ok
+    end
+  end
+
+  class << self
+    def issue_initial_code(email:)
+      issue_code(email:, resend: false)
+    end
+
+    def resend_code(email:)
+      issue_code(email:, resend: true)
+    end
+
+    def verify_code(email:, submitted_code:)
+      normalized_email = normalize_email(email)
+      code = submitted_code.to_s.strip
+      return VerifyResult.new(status: :blank, remaining_attempts: PasswordResetCode::MAX_ATTEMPTS) if code.blank?
+
+      record = PasswordResetCode.find_by(email: normalized_email)
+      return VerifyResult.new(status: :missing, remaining_attempts: 0) unless record
+      return VerifyResult.new(status: :used, remaining_attempts: 0) if record.consumed?
+      return VerifyResult.new(status: :expired, remaining_attempts: 0) if record.expired?
+      return VerifyResult.new(status: :attempt_limit, remaining_attempts: 0) if record.attempts_exhausted?
+
+      if BCrypt::Password.new(record.code_digest).is_password?(code)
+        VerifyResult.new(
+          status: :ok,
+          remaining_attempts: [PasswordResetCode::MAX_ATTEMPTS - record.attempt_count, 0].max
+        )
+      else
+        record.increment!(:attempt_count)
+        remaining_attempts = [PasswordResetCode::MAX_ATTEMPTS - record.attempt_count, 0].max
+        status = remaining_attempts.zero? ? :attempt_limit : :invalid
+        VerifyResult.new(status:, remaining_attempts:)
+      end
+    end
+
+    def consume_code!(email:)
+      record = PasswordResetCode.find_by!(email: normalize_email(email))
+      record.update!(used_at: Time.current)
+    end
+
+    private
+
+    def issue_code(email:, resend:)
+      normalized_email = normalize_email(email)
+      record = PasswordResetCode.find_or_initialize_by(email: normalized_email)
+      now = Time.current
+
+      if resend && !record.persisted?
+        return IssueResult.new(status: :missing)
+      end
+
+      cooldown_seconds = record.resend_cooldown_seconds(now)
+      if cooldown_seconds.positive?
+        return IssueResult.new(status: :cooldown, cooldown_seconds:)
+      end
+
+      if resend && record.resend_count >= PasswordResetCode::MAX_RESENDS
+        return IssueResult.new(status: :resend_limit)
+      end
+
+      code = generate_code
+      record.code_digest = BCrypt::Password.create(code)
+      record.expires_at = now + PasswordResetCode::CODE_TTL
+      record.used_at = nil
+      record.attempt_count = 0
+      record.last_sent_at = now
+      record.resend_count = resend && record.persisted? ? record.resend_count + 1 : 0
+      record.save!
+
+      delivery = ResendEmailService.send_password_reset_code(email: normalized_email, code: code)
+      return IssueResult.new(status: :delivery_unavailable) unless delivery
+
+      IssueResult.new(status: :sent)
+    rescue ResendEmailService::DeliveryError => e
+      Rails.logger.error("[PasswordReset] Code delivery failed: #{e.message}")
+      IssueResult.new(status: :delivery_failed)
+    end
+
+    def generate_code
+      format(CODE_FORMAT, SecureRandom.random_number(1_000_000))
+    end
+
+    def normalize_email(email)
+      email.to_s.strip.downcase
+    end
+  end
+end

--- a/app/services/resend_email_service.rb
+++ b/app/services/resend_email_service.rb
@@ -1,10 +1,11 @@
 # Service wrapper for sending emails via the Resend API.
-# Used for booking notifications and signup verification delivery.
+# Used for booking notifications, signup verification, and password reset delivery.
 #
 # Usage:
 #   ResendEmailService.send_booking_approved(booking)
 #   ResendEmailService.send_booking_rejected(booking, reason: "Conflict")
 #   ResendEmailService.send_signup_verification_code(email: "user@link.cuhk.edu.hk", code: "123456")
+#   ResendEmailService.send_password_reset_code(email: "user@link.cuhk.edu.hk", code: "123456")
 #
 class ResendEmailService
   class DeliveryError < StandardError; end
@@ -33,6 +34,16 @@ class ResendEmailService
 
       subject = "Your CUHK signup verification code"
       body = signup_verification_email_body(code)
+      send_email(to: email, subject:, html_content: body)
+    end
+
+    def send_password_reset_code(email:, code:)
+      if Rails.env.test?
+        return PasswordResetMailer.with(email:, code:).verification_code.deliver_now
+      end
+
+      subject = "Your CUHK password reset code"
+      body = password_reset_email_body(code)
       send_email(to: email, subject:, html_content: body)
     end
 
@@ -105,6 +116,16 @@ class ResendEmailService
         <p><strong style="font-size: 1.5rem; letter-spacing: 0.12em;">#{code}</strong></p>
         <p>This code will expire in 10 minutes.</p>
         <p>If you did not request this, you can ignore this email.</p>
+      HTML
+    end
+
+    def password_reset_email_body(code)
+      <<~HTML
+        <p>Hello,</p>
+        <p>Your CUHK Booking System password reset code is:</p>
+        <p><strong style="font-size: 1.5rem; letter-spacing: 0.12em;">#{code}</strong></p>
+        <p>This code will expire in 10 minutes.</p>
+        <p>If you did not request a password reset, you can ignore this email.</p>
       HTML
     end
 

--- a/app/views/password_reset_mailer/verification_code.html.erb
+++ b/app/views/password_reset_mailer/verification_code.html.erb
@@ -1,0 +1,9 @@
+<p>Hello,</p>
+
+<p>Your CUHK Booking System password reset code is:</p>
+
+<p><strong style="font-size: 1.5rem; letter-spacing: 0.12em;"><%= @code %></strong></p>
+
+<p>This code will expire in 10 minutes.</p>
+
+<p>If you did not request a password reset, you can ignore this email.</p>

--- a/app/views/password_reset_mailer/verification_code.text.erb
+++ b/app/views/password_reset_mailer/verification_code.text.erb
@@ -1,0 +1,5 @@
+Your CUHK Booking System password reset code is: <%= @code %>
+
+This code will expire in 10 minutes.
+
+If you did not request a password reset, you can ignore this email.

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,53 @@
+<div class="auth-page">
+  <div class="auth-card">
+    <div class="auth-logo">
+      <h1>Reset Password</h1>
+      <p>Use your CUHK email to receive a verification code</p>
+    </div>
+
+    <% if flash[:alert] %>
+      <div class="alert"><%= flash[:alert] %></div>
+    <% end %>
+
+    <% reset_local_part_value = params[:email_local_part].presence || params[:email].to_s.split("@", 2).first %>
+
+    <%= form_with url: password_reset_path,
+                  method: :post,
+                  data: {
+                    turbo: false,
+                    controller: "domain-lock-email",
+                    domain_lock_email_domain_value: User::CUHK_EMAIL_DOMAIN
+                  } do |f| %>
+      <div class="form-group">
+        <%= f.label :email_local_part, "Email" %>
+        <div class="domain-email-input">
+          <%= f.text_field :email_local_part,
+                          value: reset_local_part_value,
+                          required: true,
+                          autofocus: true,
+                          autocomplete: "username",
+                          pattern: "[^@\\s]+",
+                          title: "Enter your CUHK account local part only.",
+                          placeholder: "e.g. 1155209296",
+                          data: {
+                            domain_lock_email_target: "localPart",
+                            action: "input->domain-lock-email#sanitize input->domain-lock-email#updatePreview"
+                          } %>
+          <span class="domain-email-suffix">@link.cuhk.edu.hk</span>
+        </div>
+        <p class="form-hint">
+          Enter only your student ID/local part.
+          Full email: <strong data-domain-lock-email-target="fullPreview"></strong>
+        </p>
+      </div>
+
+      <div>
+        <%= f.submit "Send Verification Code", class: "btn-primary" %>
+      </div>
+    <% end %>
+
+    <div class="auth-footer">
+      Remembered your password? <%= link_to "Back to sign in", login_path %>
+    </div>
+  </div>
+</div>

--- a/app/views/password_resets/verify.html.erb
+++ b/app/views/password_resets/verify.html.erb
@@ -1,0 +1,57 @@
+<div class="auth-page">
+  <div class="auth-card">
+    <div class="auth-logo">
+      <h1>Verify and Reset Password</h1>
+      <p>Enter the 6-digit code sent to <strong><%= @pending_email %></strong></p>
+    </div>
+
+    <% if flash[:alert] %>
+      <div class="alert"><%= flash[:alert] %></div>
+    <% end %>
+
+    <%= form_with url: password_reset_verify_code_path, method: :post, data: { turbo: false } do |f| %>
+      <div class="form-group">
+        <%= f.label :verification_code, "Verification Code" %>
+        <%= f.text_field :verification_code,
+                         required: true,
+                         autofocus: true,
+                         maxlength: 6,
+                         pattern: "\\d{6}",
+                         inputmode: "numeric",
+                         autocomplete: "one-time-code",
+                         placeholder: "123456" %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :password, "New Password" %>
+        <%= f.password_field :password,
+                             required: true,
+                             minlength: 8,
+                             autocomplete: "new-password",
+                             placeholder: "Enter a new password" %>
+      </div>
+
+      <div class="form-group">
+        <%= f.label :password_confirmation, "Confirm New Password" %>
+        <%= f.password_field :password_confirmation,
+                             required: true,
+                             minlength: 8,
+                             autocomplete: "new-password",
+                             placeholder: "Confirm your new password" %>
+      </div>
+
+      <div>
+        <%= f.submit "Verify and Reset Password", class: "btn-primary" %>
+      </div>
+    <% end %>
+
+    <div class="auth-footer">
+      <%= form_with url: password_reset_resend_code_path, method: :post, data: { turbo: false }, class: "inline" do |f| %>
+        <%= f.submit "Resend code", class: "btn btn-secondary btn-sm" %>
+      <% end %>
+      <div class="mt-1">
+        Wrong email? <%= link_to "Start over", password_reset_path %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -52,7 +52,8 @@
     <% end %>
 
     <div class="auth-footer">
-      Don't have an account? <%= link_to "Create one", signup_path %>
+      Don't have an account? <%= link_to "Create one", signup_path %><br>
+      Forgot your password? <%= link_to "Reset it", password_reset_path %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,12 @@ Rails.application.routes.draw do
   post "signup/verify", to: "registrations#verify_code", as: :signup_verify_code
   post "signup/resend_code", to: "registrations#resend_code", as: :signup_resend_code
 
+  get  "password_reset", to: "password_resets#new"
+  post "password_reset", to: "password_resets#create"
+  get  "password_reset/verify", to: "password_resets#verify", as: :password_reset_verify
+  post "password_reset/verify", to: "password_resets#update", as: :password_reset_verify_code
+  post "password_reset/resend_code", to: "password_resets#resend_code", as: :password_reset_resend_code
+
   get "dashboard", to: "dashboards#show"
   get "approval_dashboard", to: "dashboards#approvals"
   get "admin",     to: "admin#show"

--- a/db/migrate/20260413092500_create_password_reset_codes.rb
+++ b/db/migrate/20260413092500_create_password_reset_codes.rb
@@ -1,0 +1,20 @@
+class CreatePasswordResetCodes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :password_reset_codes do |t|
+      t.string :email, null: false
+      t.string :code_digest, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :used_at
+      t.integer :attempt_count, null: false, default: 0
+      t.integer :resend_count, null: false, default: 0
+      t.datetime :last_sent_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :password_reset_codes, :email, unique: true
+    add_index :password_reset_codes, :expires_at
+    add_check_constraint :password_reset_codes, "attempt_count >= 0", name: "password_reset_codes_attempt_count_non_negative"
+    add_check_constraint :password_reset_codes, "resend_count >= 0", name: "password_reset_codes_resend_count_non_negative"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_09_192339) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_092500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -68,6 +68,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_09_192339) do
     t.bigint "tenant_id", null: false
     t.datetime "updated_at", null: false
     t.index ["tenant_id"], name: "index_equipment_on_tenant_id"
+  end
+
+  create_table "password_reset_codes", force: :cascade do |t|
+    t.integer "attempt_count", default: 0, null: false
+    t.string "code_digest", null: false
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "last_sent_at", null: false
+    t.integer "resend_count", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.datetime "used_at"
+    t.index ["email"], name: "index_password_reset_codes_on_email", unique: true
+    t.index ["expires_at"], name: "index_password_reset_codes_on_expires_at"
+    t.check_constraint "attempt_count >= 0", name: "password_reset_codes_attempt_count_non_negative"
+    t.check_constraint "resend_count >= 0", name: "password_reset_codes_resend_count_non_negative"
   end
 
   create_table "signup_verification_codes", force: :cascade do |t|

--- a/spec/factories/password_reset_codes.rb
+++ b/spec/factories/password_reset_codes.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :password_reset_code do
+    sequence(:email) { |n| "reset#{n}@link.cuhk.edu.hk" }
+    code_digest { BCrypt::Password.create("123456") }
+    expires_at { 10.minutes.from_now }
+    used_at { nil }
+    attempt_count { 0 }
+    resend_count { 0 }
+    last_sent_at { Time.current }
+  end
+end

--- a/spec/mailers/password_reset_mailer_spec.rb
+++ b/spec/mailers/password_reset_mailer_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe PasswordResetMailer, type: :mailer do
+  describe "verification_code" do
+    let(:recipient) { "resetstudent@link.cuhk.edu.hk" }
+    let(:verification_code) { "123456" }
+    let(:mail) do
+      described_class.with(email: recipient, code: verification_code).verification_code
+    end
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Your CUHK password reset code")
+      expect(mail.to).to eq([recipient])
+      expect(mail.from).to eq([ENV.fetch("RESEND_FROM_EMAIL", "noreply@csci3100.tylerl.cyou")])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to include(verification_code)
+      expect(mail.body.encoded).to include("This code will expire in 10 minutes.")
+    end
+  end
+end

--- a/spec/models/password_reset_code_spec.rb
+++ b/spec/models/password_reset_code_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe PasswordResetCode, type: :model do
+  subject(:reset_code) { build(:password_reset_code) }
+
+  it "is valid with default factory attributes" do
+    expect(reset_code).to be_valid
+  end
+
+  it "normalizes email casing and whitespace" do
+    reset_code.email = "  MixedCase@link.cuhk.edu.hk  "
+    reset_code.validate
+
+    expect(reset_code.email).to eq("mixedcase@link.cuhk.edu.hk")
+  end
+
+  it "requires a CUHK email" do
+    reset_code.email = "student@example.com"
+
+    expect(reset_code).not_to be_valid
+    expect(reset_code.errors[:email]).to include("must be a valid @link.cuhk.edu.hk address")
+  end
+
+  describe "#attempts_exhausted?" do
+    it "returns true at max attempts" do
+      reset_code.attempt_count = PasswordResetCode::MAX_ATTEMPTS
+      expect(reset_code.attempts_exhausted?).to be(true)
+    end
+
+    it "returns false under max attempts" do
+      reset_code.attempt_count = PasswordResetCode::MAX_ATTEMPTS - 1
+      expect(reset_code.attempts_exhausted?).to be(false)
+    end
+  end
+
+  describe "#expired?" do
+    it "returns true when expiry time has passed" do
+      reset_code.expires_at = 1.minute.ago
+      expect(reset_code.expired?).to be(true)
+    end
+
+    it "returns false when still within validity window" do
+      reset_code.expires_at = 5.minutes.from_now
+      expect(reset_code.expired?).to be(false)
+    end
+  end
+
+  describe "#resend_cooldown_seconds" do
+    it "returns a positive value during cooldown" do
+      reset_code.last_sent_at = Time.current
+      expect(reset_code.resend_cooldown_seconds).to be > 0
+    end
+
+    it "returns zero when cooldown has elapsed" do
+      reset_code.last_sent_at = 2.minutes.ago
+      expect(reset_code.resend_cooldown_seconds).to eq(0)
+    end
+  end
+end

--- a/spec/requests/password_resets_spec.rb
+++ b/spec/requests/password_resets_spec.rb
@@ -1,0 +1,168 @@
+require "rails_helper"
+
+RSpec.describe "PasswordResets", type: :request do
+  let!(:student_user) { create(:user, :student, email: "studentreset@link.cuhk.edu.hk") }
+  let!(:staff_user) { create(:user, :staff, email: "staffreset@link.cuhk.edu.hk") }
+  let!(:root_staff_user) { create(:user, :root_account, email: "rootreset@link.cuhk.edu.hk") }
+  let!(:admin_user) { create(:user, :admin, email: "adminreset@link.cuhk.edu.hk") }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe "GET /password_reset" do
+    it "renders the reset password form" do
+      get password_reset_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Reset Password")
+      expect(response.body).to include("@link.cuhk.edu.hk")
+    end
+  end
+
+  describe "POST /password_reset" do
+    it "sends a verification code for students" do
+      expect {
+        post password_reset_path, params: { email: student_user.email }
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(response).to redirect_to(password_reset_verify_path)
+      expect(flash[:notice]).to include("Verification code sent")
+
+      record = PasswordResetCode.find_by(email: student_user.email)
+      expect(record).to be_present
+      expect(request.session[:pending_password_reset]["email"]).to eq(student_user.email)
+    end
+
+    it "sends a verification code for non-root staff" do
+      post password_reset_path, params: { email: staff_user.email }
+
+      expect(response).to redirect_to(password_reset_verify_path)
+      expect(PasswordResetCode.find_by(email: staff_user.email)).to be_present
+    end
+
+    it "accepts email local part and canonicalizes to CUHK email" do
+      post password_reset_path, params: { email_local_part: "studentreset" }
+
+      expect(response).to redirect_to(password_reset_verify_path)
+      expect(PasswordResetCode.find_by(email: "studentreset@link.cuhk.edu.hk")).to be_present
+    end
+
+    it "does not reveal whether a non-existent account exists" do
+      expect {
+        post password_reset_path, params: { email: "missingaccount@link.cuhk.edu.hk" }
+      }.not_to change { ActionMailer::Base.deliveries.count }
+
+      expect(response).to redirect_to(password_reset_path)
+      expect(flash[:notice]).to eq("If an eligible account exists for this email, a verification code has been sent.")
+      expect(PasswordResetCode.find_by(email: "missingaccount@link.cuhk.edu.hk")).to be_nil
+    end
+
+    it "rejects root staff accounts" do
+      expect {
+        post password_reset_path, params: { email: root_staff_user.email }
+      }.not_to change { ActionMailer::Base.deliveries.count }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Password reset is only available for student and non-root staff accounts.")
+      expect(PasswordResetCode.find_by(email: root_staff_user.email)).to be_nil
+    end
+
+    it "rejects admin accounts" do
+      expect {
+        post password_reset_path, params: { email: admin_user.email }
+      }.not_to change { ActionMailer::Base.deliveries.count }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Password reset is only available for student and non-root staff accounts.")
+      expect(PasswordResetCode.find_by(email: admin_user.email)).to be_nil
+    end
+  end
+
+  describe "GET /password_reset/verify" do
+    it "requires a pending reset session" do
+      get password_reset_verify_path
+
+      expect(response).to redirect_to(password_reset_path)
+      expect(flash[:alert]).to eq("Please request a verification code first.")
+    end
+  end
+
+  describe "POST /password_reset/verify" do
+    before do
+      student_user.update!(active_session_token: SecureRandom.hex(32))
+      post password_reset_path, params: { email: student_user.email }
+    end
+
+    it "resets password after valid verification code" do
+      code = ActionMailer::Base.deliveries.last.body.encoded[/\b\d{6}\b/]
+
+      post password_reset_verify_code_path, params: {
+        verification_code: code,
+        password: "NewPassword1!",
+        password_confirmation: "NewPassword1!"
+      }
+
+      expect(response).to redirect_to(login_path)
+      expect(student_user.reload.authenticate("NewPassword1!")).to be_present
+      expect(student_user.active_session_token).to be_nil
+      expect(PasswordResetCode.find_by(email: student_user.email).used_at).to be_present
+    end
+
+    it "rejects invalid verification code" do
+      previous_digest = student_user.password_digest
+
+      post password_reset_verify_code_path, params: {
+        verification_code: "000000",
+        password: "NewPassword1!",
+        password_confirmation: "NewPassword1!"
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Invalid verification code. Attempts remaining:")
+      expect(student_user.reload.password_digest).to eq(previous_digest)
+    end
+
+    it "rejects blank password submission" do
+      code = ActionMailer::Base.deliveries.last.body.encoded[/\b\d{6}\b/]
+
+      post password_reset_verify_code_path, params: {
+        verification_code: code,
+        password: "",
+        password_confirmation: ""
+      }
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to match(/Password can(?:&#39;|')t be blank\./)
+      expect(PasswordResetCode.find_by(email: student_user.email).used_at).to be_nil
+    end
+  end
+
+  describe "POST /password_reset/resend_code" do
+    before do
+      post password_reset_path, params: { email: student_user.email }
+    end
+
+    it "resends code after cooldown" do
+      record = PasswordResetCode.find_by!(email: student_user.email)
+      record.update!(last_sent_at: 2.minutes.ago)
+
+      expect {
+        post password_reset_resend_code_path
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(response).to redirect_to(password_reset_verify_path)
+      expect(flash[:notice]).to eq("A new verification code has been sent.")
+      expect(record.reload.resend_count).to eq(1)
+    end
+
+    it "throttles resend requests made too quickly" do
+      expect {
+        post password_reset_resend_code_path
+      }.not_to change { ActionMailer::Base.deliveries.count }
+
+      expect(response).to redirect_to(password_reset_verify_path)
+      expect(flash[:alert]).to include("Please wait")
+    end
+  end
+end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Sessions', type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include('Sign In')
       expect(response.body).to include('@link.cuhk.edu.hk')
+      expect(response.body).to include('Forgot your password?')
     end
   end
 

--- a/spec/services/password_reset_service_spec.rb
+++ b/spec/services/password_reset_service_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe PasswordResetService do
+  let(:email) { "resetstudent@link.cuhk.edu.hk" }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  describe ".issue_initial_code" do
+    it "creates a reset record and sends an email" do
+      result = described_class.issue_initial_code(email:)
+
+      expect(result.status).to eq(:sent)
+      record = PasswordResetCode.find_by!(email:)
+      expect(record.expires_at).to be > Time.current
+      expect(record.attempt_count).to eq(0)
+      expect(record.resend_count).to eq(0)
+
+      mail = ActionMailer::Base.deliveries.last
+      delivered_code = mail.body.encoded[/\b\d{6}\b/]
+      expect(mail.to).to eq([email])
+      expect(delivered_code).to be_present
+      expect(BCrypt::Password.new(record.code_digest).is_password?(delivered_code)).to be(true)
+    end
+  end
+
+  describe ".verify_code" do
+    it "accepts a valid code and rejects it after consumption" do
+      described_class.issue_initial_code(email:)
+      code = ActionMailer::Base.deliveries.last.body.encoded[/\b\d{6}\b/]
+
+      verify_result = described_class.verify_code(email:, submitted_code: code)
+      expect(verify_result.success?).to be(true)
+
+      described_class.consume_code!(email:)
+      reused_result = described_class.verify_code(email:, submitted_code: code)
+      expect(reused_result.status).to eq(:used)
+    end
+
+    it "tracks invalid attempts and locks after limit" do
+      described_class.issue_initial_code(email:)
+
+      PasswordResetCode::MAX_ATTEMPTS.times do
+        described_class.verify_code(email:, submitted_code: "000000")
+      end
+
+      record = PasswordResetCode.find_by!(email:)
+      expect(record.attempt_count).to eq(PasswordResetCode::MAX_ATTEMPTS)
+
+      result = described_class.verify_code(email:, submitted_code: "000000")
+      expect(result.status).to eq(:attempt_limit)
+      expect(result.remaining_attempts).to eq(0)
+    end
+
+    it "rejects expired codes" do
+      create(
+        :password_reset_code,
+        email:,
+        code_digest: BCrypt::Password.create("123456"),
+        expires_at: 1.minute.ago
+      )
+
+      result = described_class.verify_code(email:, submitted_code: "123456")
+      expect(result.status).to eq(:expired)
+    end
+  end
+
+  describe ".resend_code" do
+    it "enforces cooldown and resend limit" do
+      described_class.issue_initial_code(email:)
+      cooldown_result = described_class.resend_code(email:)
+      expect(cooldown_result.status).to eq(:cooldown)
+
+      record = PasswordResetCode.find_by!(email:)
+      record.update!(last_sent_at: 2.minutes.ago)
+
+      resend_result = described_class.resend_code(email:)
+      expect(resend_result.status).to eq(:sent)
+      expect(record.reload.resend_count).to eq(1)
+
+      record.update!(last_sent_at: 2.minutes.ago, resend_count: PasswordResetCode::MAX_RESENDS)
+      limit_result = described_class.resend_code(email:)
+      expect(limit_result.status).to eq(:resend_limit)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a forgot-password flow using email OTP (request, verify, resend)
- restrict reset eligibility to students and non-root staff
- clear active session lock after successful password reset
- add password reset model/service/mailer + migration and specs
- harden reset request behavior for non-existent emails by returning a generic notice instead of role-based rejection

## Validation
- bin/rubocop
- bundle exec rspec