### PR TITLE
Fix stale active-session lockouts for login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,11 +19,20 @@ class ApplicationController < ActionController::Base
     return @current_user if user_id.blank?
 
     user = User.find_by(id: user_id)
-    unless user && user.active_session_token_matches?(session[:active_session_token])
+    session_token = session[:active_session_token]
+
+    unless user&.active_session_token_matches?(session_token)
       reset_session
       return @current_user
     end
 
+    if user.active_session_lock_expired?
+      user.clear_expired_active_session_lock!
+      reset_session
+      return @current_user
+    end
+
+    user.touch_active_session_lock!(token: session_token)
     @current_user = user
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -35,6 +35,7 @@ class SessionsController < ApplicationController
 
     user.with_lock do
       user.reload
+      user.clear_expired_active_session_lock!
       return false if user.active_session_locked?
 
       session_token = user.issue_active_session_token!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@ class User < ApplicationRecord
   scope :root_accounts, -> { where(is_root_account: true) }
 
   SESSION_TOKEN_LENGTH = 64
+  DEFAULT_ACTIVE_SESSION_LOCK_TIMEOUT = 12.hours
+  DEFAULT_ACTIVE_SESSION_LOCK_TOUCH_INTERVAL = 5.minutes
   CUHK_EMAIL_DOMAIN = "link.cuhk.edu.hk"
   CUHK_EMAIL_REGEX = /\A[a-zA-Z0-9._%+-]+@#{Regexp.escape(CUHK_EMAIL_DOMAIN)}\z/i
 
@@ -34,20 +36,49 @@ class User < ApplicationRecord
     true
   end
 
-  def active_session_locked?
-    active_session_token.present?
+  def self.active_session_lock_timeout
+    timeout_seconds = ENV.fetch("ACTIVE_SESSION_LOCK_TIMEOUT_SECONDS", DEFAULT_ACTIVE_SESSION_LOCK_TIMEOUT.to_i).to_i
+    timeout_seconds = DEFAULT_ACTIVE_SESSION_LOCK_TIMEOUT.to_i if timeout_seconds <= 0
+    timeout_seconds.seconds
   end
 
-  def issue_active_session_token!
+  def self.active_session_lock_touch_interval
+    interval_seconds = ENV.fetch("ACTIVE_SESSION_LOCK_TOUCH_INTERVAL_SECONDS", DEFAULT_ACTIVE_SESSION_LOCK_TOUCH_INTERVAL.to_i).to_i
+    interval_seconds = DEFAULT_ACTIVE_SESSION_LOCK_TOUCH_INTERVAL.to_i if interval_seconds <= 0
+    interval_seconds.seconds
+  end
+
+  def active_session_locked?(reference_time: Time.current)
+    active_session_token.present? && !active_session_lock_expired?(reference_time: reference_time)
+  end
+
+  def issue_active_session_token!(issued_at: Time.current)
     token = SecureRandom.hex(SESSION_TOKEN_LENGTH / 2)
-    update!(active_session_token: token)
+    update!(active_session_token: token, active_session_token_issued_at: issued_at)
     token
   end
 
   def clear_active_session_token!(token:)
     return unless active_session_token_matches?(token)
 
-    update!(active_session_token: nil)
+    clear_active_session_lock!
+  end
+
+  def clear_expired_active_session_lock!(reference_time: Time.current)
+    return false unless active_session_lock_expired?(reference_time: reference_time)
+
+    clear_active_session_lock!
+    true
+  end
+
+  def touch_active_session_lock!(token:, reference_time: Time.current)
+    return false unless active_session_token_matches?(token)
+    return false if active_session_lock_expired?(reference_time: reference_time)
+    return false if active_session_token_issued_at.present? &&
+                    active_session_token_issued_at >= (reference_time - self.class.active_session_lock_touch_interval)
+
+    update!(active_session_token_issued_at: reference_time)
+    true
   end
 
   def active_session_token_matches?(token)
@@ -55,6 +86,15 @@ class User < ApplicationRecord
     return false if active_session_token.blank? || submitted_token.blank?
 
     ActiveSupport::SecurityUtils.secure_compare(active_session_token, submitted_token)
+  end
+
+  def active_session_lock_expired?(reference_time: Time.current)
+    return false if active_session_token.blank?
+
+    issued_at = active_session_token_issued_at
+    return true if issued_at.blank?
+
+    issued_at <= (reference_time - self.class.active_session_lock_timeout)
   end
 
   def self.canonicalize_cuhk_email(local_part_or_email)
@@ -75,4 +115,10 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: :new_record?
 
   normalizes :email, with: ->(email) { email.strip.downcase }
+
+  private
+
+  def clear_active_session_lock!
+    update!(active_session_token: nil, active_session_token_issued_at: nil)
+  end
 end

--- a/db/migrate/20260413130000_add_active_session_token_issued_at_to_users.rb
+++ b/db/migrate/20260413130000_add_active_session_token_issued_at_to_users.rb
@@ -1,0 +1,16 @@
+class AddActiveSessionTokenIssuedAtToUsers < ActiveRecord::Migration[8.1]
+  def up
+    add_column :users, :active_session_token_issued_at, :datetime
+
+    execute <<~SQL.squish
+      UPDATE users
+      SET active_session_token_issued_at = CURRENT_TIMESTAMP
+      WHERE active_session_token IS NOT NULL
+        AND active_session_token_issued_at IS NULL
+    SQL
+  end
+
+  def down
+    remove_column :users, :active_session_token_issued_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_09_192339) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_130000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -105,6 +105,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_09_192339) do
 
   create_table "users", force: :cascade do |t|
     t.string "active_session_token"
+    t.datetime "active_session_token_issued_at"
     t.string "college_scope_slug"
     t.datetime "created_at", null: false
     t.string "email", null: false

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  include ActiveSupport::Testing::TimeHelpers
+
   describe 'validations' do
     it 'is valid with valid attributes' do
       expect(build(:user, :admin)).to be_valid
@@ -91,6 +93,38 @@ RSpec.describe User, type: :model do
 
     it 'rejects incorrect password' do
       expect(user.authenticate('wrongpassword')).to be_falsey
+    end
+  end
+
+  describe 'active session lock' do
+    let(:user) { create(:user, :admin) }
+
+    it 'stores an issued timestamp when creating a session token' do
+      travel_to(Time.zone.parse('2026-04-13 12:00:00 UTC')) do
+        user.issue_active_session_token!
+
+        expect(user.reload.active_session_token).to be_present
+        expect(user.active_session_token_issued_at).to eq(Time.current)
+      end
+    end
+
+    it 'treats legacy lock records without timestamp as expired' do
+      user.update!(active_session_token: SecureRandom.hex(32), active_session_token_issued_at: nil)
+
+      expect(user.active_session_lock_expired?).to be(true)
+    end
+
+    it 'clears lock columns when the lock has expired' do
+      user.update!(
+        active_session_token: SecureRandom.hex(32),
+        active_session_token_issued_at: 13.hours.ago
+      )
+
+      expect(user.clear_expired_active_session_lock!).to be(true)
+      user.reload
+
+      expect(user.active_session_token).to be_nil
+      expect(user.active_session_token_issued_at).to be_nil
     end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Sessions', type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
   let!(:user) { create(:user, :admin) }
 
   describe 'GET /login' do
@@ -43,6 +45,20 @@ RSpec.describe 'Sessions', type: :request do
 
       browser_one.get dashboard_path
       expect(browser_one.status).to eq(200)
+    end
+
+    it 'allows login when an existing lock is stale' do
+      stale_token = SecureRandom.hex(32)
+      user.update!(
+        active_session_token: stale_token,
+        active_session_token_issued_at: 13.hours.ago
+      )
+
+      post login_path, params: { email: user.email, password: 'Password1!' }
+
+      expect(response).to redirect_to(dashboard_path)
+      expect(user.reload.active_session_token).not_to eq(stale_token)
+      expect(user.active_session_token_issued_at).to be_present
     end
 
     it 'rejects invalid credentials' do
@@ -95,6 +111,19 @@ RSpec.describe 'Sessions', type: :request do
 
       get dashboard_path
       expect(response).to redirect_to(login_path)
+    end
+
+    it 'invalidates sessions after lock timeout and releases stale lock' do
+      log_in_as(user)
+
+      travel_to(User.active_session_lock_timeout.from_now + 1.second) do
+        get dashboard_path
+        expect(response).to redirect_to(login_path)
+      end
+
+      user.reload
+      expect(user.active_session_token).to be_nil
+      expect(user.active_session_token_issued_at).to be_nil
     end
 
     it 'hides Booking link for society member dashboard' do


### PR DESCRIPTION
Summary:
- add active_session_token_issued_at to track when an account lock was created
- make active-session locks expire after a configurable timeout (default 12 hours)
- auto-clear expired locks during login and authenticated requests so abandoned sessions do not block future logins
- refresh lock timestamp for active sessions at a throttled interval (default 5 minutes)
- add request and model regression specs for stale lock recovery and timeout invalidation

Production incident handling:
- verified production admin@link.cuhk.edu.hk was locked due to stale active_session_token
- manually cleared that token on the Azure VM so admin login is immediately unblocked

Validation:
- bin/rubocop app/controllers/application_controller.rb app/controllers/sessions_controller.rb app/models/user.rb spec/models/user_spec.rb spec/requests/sessions_spec.rb db/migrate/20260413130000_add_active_session_token_issued_at_to_users.rb
- bundle exec rspec
- bundle exec cucumber