### PR TITLE
Fix login CSRF mismatch after stale session reset

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,11 @@
 class SessionsController < ApplicationController
   skip_before_action :require_authentication, only: [:new, :create]
+  before_action :resolve_current_session_user, only: :new
 
   def new
+    @login_form_authenticity_token = form_authenticity_token(
+      form_options: { action: login_path, method: :post }
+    )
   end
 
   def create
@@ -29,6 +33,10 @@ class SessionsController < ApplicationController
   end
 
   private
+
+  def resolve_current_session_user
+    current_user
+  end
 
   def establish_session_lock!(user)
     session_token = nil

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,5 @@
+<%# Resolve current_user before generating CSRF tags so stale-session resets happen first. %>
+<% authenticated_user = current_user %>
 <!DOCTYPE html>
 <html>
   <head>
@@ -22,7 +24,7 @@
   </head>
 
   <body>
-    <% if logged_in? %>
+    <% if authenticated_user.present? %>
       <%# ===== App Layout with Sidebar ===== %>
       <div class="app-layout">
         <div class="sidebar-overlay" id="sidebarOverlay" onclick="closeSidebar()"></div>
@@ -39,7 +41,7 @@
             <div class="sidebar-section">Main</div>
             <%= nav_link "Dashboard", dashboard_path, icon: "\u{1F3E0}", controllers: %w[dashboards], actions: %w[show] %>
 
-            <% if current_user.student? %>
+            <% if authenticated_user.student? %>
               <%= nav_link "My Bookings", my_bookings_path, icon: "\u{1F4CB}", controllers: %w[bookings], actions: %w[my] %>
             <% end %>
 
@@ -47,22 +49,22 @@
             <%= nav_link "Venues", venues_path, icon: "\u{1F3DB}", controllers: %w[venues] %>
             <%= nav_link "Equipment", equipments_path, icon: "\u{1F527}", controllers: %w[equipments] %>
 
-            <% unless current_user.student? %>
+            <% unless authenticated_user.student? %>
               <div class="sidebar-section">Management</div>
               <%= nav_link "All Bookings", bookings_path, icon: "\u{1F4C5}", controllers: %w[bookings] %>
               <%= nav_link "Approvals", approval_dashboard_path, icon: "\u2705", controllers: %w[dashboards], actions: %w[approvals] %>
               <%= nav_link "Venue Requests", venue_requests_path, icon: "\u{1F3D7}", controllers: %w[venue_requests] %>
-              <% if current_user.staff? && current_user.root_account? %>
+              <% if authenticated_user.staff? && authenticated_user.root_account? %>
                 <%= nav_link "Staff Accounts", staff_accounts_path, icon: "\u{1F465}", controllers: %w[staff_accounts] %>
               <% end %>
             <% end %>
 
-            <% if current_user.admin? || current_user.staff? %>
+            <% if authenticated_user.admin? || authenticated_user.staff? %>
               <div class="sidebar-section">Insights</div>
               <%= nav_link "Analytics", analytics_path, icon: "\u{1F4CA}", controllers: %w[analytics] %>
             <% end %>
 
-            <% if current_user.admin? %>
+            <% if authenticated_user.admin? %>
               <div class="sidebar-section">Admin</div>
               <%= nav_link "Admin Panel", admin_path, icon: "\u2699\uFE0F", controllers: %w[admin] %>
             <% end %>
@@ -70,10 +72,10 @@
 
           <div class="sidebar-footer">
             <div class="sidebar-user">
-              <div class="sidebar-avatar"><%= user_initials(current_user) %></div>
+              <div class="sidebar-avatar"><%= user_initials(authenticated_user) %></div>
               <div class="sidebar-user-info">
-                <span class="sidebar-user-email"><%= current_user.email %></span>
-                <span class="sidebar-user-role"><%= current_user.role.humanize %></span>
+                <span class="sidebar-user-email"><%= authenticated_user.email %></span>
+                <span class="sidebar-user-role"><%= authenticated_user.role.humanize %></span>
               </div>
             </div>
             <div class="sidebar-logout">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -13,6 +13,7 @@
 
     <%= form_with url: login_path,
                   method: :post,
+                  authenticity_token: @login_form_authenticity_token,
                   data: {
                     turbo: false,
                     controller: "domain-lock-email",

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -72,6 +72,53 @@ RSpec.describe 'Sessions', type: :request do
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include('Invalid email or password')
     end
+
+    it 'accepts a fresh CSRF token after invalidating a stale authenticated session' do
+      original_forgery_setting = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+
+      browser_one = ActionDispatch::Integration::Session.new(Rails.application)
+      browser_two = ActionDispatch::Integration::Session.new(Rails.application)
+
+      browser_one.get(login_path)
+      first_authenticity_token = browser_one.response.body[/<form[^>]*action="\/login"[^>]*>.*?name="authenticity_token" value="([^"]+)"/m, 1]
+      expect(first_authenticity_token).to be_present
+
+      browser_one.post(login_path, params: {
+        authenticity_token: first_authenticity_token,
+        email: user.email,
+        password: 'Password1!'
+      })
+      expect(browser_one.status).to eq(302)
+      expect(browser_one.response.headers['Location']).to end_with(dashboard_path)
+
+      travel_to(User.active_session_lock_timeout.from_now + 1.second) do
+        browser_two.get(login_path)
+        second_authenticity_token = browser_two.response.body[/<form[^>]*action="\/login"[^>]*>.*?name="authenticity_token" value="([^"]+)"/m, 1]
+        expect(second_authenticity_token).to be_present
+
+        browser_two.post(login_path, params: {
+          authenticity_token: second_authenticity_token,
+          email: user.email,
+          password: 'Password1!'
+        })
+        expect(browser_two.status).to eq(302)
+      end
+
+      browser_one.get(login_path)
+      stale_session_token = browser_one.response.body[/<form[^>]*action="\/login"[^>]*>.*?name="authenticity_token" value="([^"]+)"/m, 1]
+      expect(stale_session_token).to be_present
+
+      browser_one.post(login_path, params: {
+        authenticity_token: stale_session_token,
+        email: user.email,
+        password: 'Password1!'
+      })
+      expect(browser_one.status).to eq(409)
+      expect(browser_one.response.body).to include('already logged in on another device')
+    ensure
+      ActionController::Base.allow_forgery_protection = original_forgery_setting
+    end
   end
 
   describe 'DELETE /logout' do


### PR DESCRIPTION
## Summary\n- resolve current session user before rendering login page so stale locks are reset deterministically\n- issue a login-form scoped CSRF token from SessionsController#new and pass it explicitly to the login form\n- add request coverage for stale-session re-login with CSRF protection enabled\n\n## Testing\n- bundle exec rspec\n- bin/rubocop app/controllers/sessions_controller.rb spec/requests/sessions_spec.rb