### PR TITLE
Improve venue request and booking page usability

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -778,6 +778,42 @@ textarea { min-height: 100px; resize: vertical; }
   border-bottom: none;
 }
 
+.table-scroll-shell {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.venue-requests-table {
+  min-width: 980px;
+  table-layout: auto;
+}
+
+.venue-requests-table th,
+.venue-requests-table td {
+  white-space: nowrap;
+}
+
+.venue-requests-table .venue-request-description {
+  min-width: 220px;
+  max-width: 320px;
+  white-space: normal;
+  line-height: 1.4;
+}
+
+.venue-requests-table .venue-request-email {
+  max-width: 220px;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.venue-requests-table .venue-request-actions,
+.venue-requests-table .venue-request-actions-header {
+  min-width: 96px;
+  text-align: right;
+  white-space: nowrap;
+}
+
 /* My bookings table - same styling */
 table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) {
   width: 100%;
@@ -962,6 +998,47 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
   color: var(--gray-900);
 }
 
+.venue-request-review-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.venue-request-review-action {
+  padding: 1rem;
+  border-radius: var(--radius);
+  border: 1px solid var(--gray-200);
+}
+
+.venue-request-review-action h4 {
+  margin: 0 0 0.45rem;
+  font-size: 0.95rem;
+  color: var(--gray-900);
+}
+
+.venue-request-review-action p {
+  margin: 0 0 0.8rem;
+}
+
+.venue-request-approve-action {
+  background: var(--success-bg);
+  border-color: #A7F3D0;
+}
+
+.venue-request-reject-action {
+  background: var(--danger-bg);
+  border-color: #FECACA;
+}
+
+.venue-request-action-form,
+.venue-request-reject-form {
+  margin: 0;
+}
+
+.venue-request-review-button {
+  width: 100%;
+}
+
 /* ===== Empty State ===== */
 .empty-state {
   text-align: center;
@@ -989,11 +1066,15 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
 .booking-planner {
   display: grid;
   gap: 1.25rem;
-  max-width: 800px;
+  max-width: 920px;
+}
+
+.booking-planner-controls {
+  display: grid;
+  gap: 1rem;
 }
 
 .booking-date-filter {
-  margin-bottom: 0.5rem;
   padding: 1rem 1.25rem;
   border: 1px solid var(--gray-200);
   border-radius: var(--radius-lg);
@@ -1014,6 +1095,13 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
 .booking-field {
   display: grid;
   gap: 0.35rem;
+}
+
+.booking-time-fields {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: end;
 }
 
 .booking-label {
@@ -1066,7 +1154,7 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
   border-collapse: separate;
   border-spacing: 0;
   width: 100%;
-  max-width: 800px;
+  max-width: 920px;
   margin: 0.75rem 0 1rem;
   font-size: 0.93rem;
   border-radius: var(--radius);
@@ -1075,18 +1163,20 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
   border: 1px solid var(--gray-200);
 }
 
+.TimeTable th,
 .TimeTable td {
   border: 1px solid var(--gray-200);
   vertical-align: middle;
 }
 
 .TimeTableTitleCell {
-  width: 150px;
+  width: 210px;
   padding: 0.65rem 0.85rem;
   font-weight: 700;
   background: var(--gray-100);
   color: var(--gray-700);
   font-size: 0.85rem;
+  white-space: nowrap;
 }
 
 .TimeTableTitleCellOneDayOneFacilityView {
@@ -1117,6 +1207,12 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
   padding: 0.2rem 0.4rem;
   border-radius: 4px;
   font-weight: 500;
+}
+
+.timetable-time-range {
+  display: inline-block;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 
 .timetable-slot-unavailable {
@@ -1332,6 +1428,12 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
   }
   .dashboard-grid {
     grid-template-columns: 1fr;
+  }
+  .booking-time-fields {
+    grid-template-columns: 1fr;
+  }
+  .TimeTableTitleCell {
+    width: 170px;
   }
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -814,6 +814,46 @@ textarea { min-height: 100px; resize: vertical; }
   white-space: nowrap;
 }
 
+.venues-table {
+  min-width: 860px;
+  table-layout: fixed;
+}
+
+.venues-table .venues-col-name {
+  width: 24%;
+}
+
+.venues-table .venues-col-name a {
+  overflow-wrap: anywhere;
+}
+
+.venues-table .venues-col-description {
+  width: 42%;
+  white-space: normal;
+  line-height: 1.4;
+}
+
+.venues-table .venues-col-department {
+  width: 18%;
+  white-space: nowrap;
+}
+
+.venues-table .venues-col-actions {
+  width: 16%;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.venues-actions-group {
+  justify-content: flex-end;
+  flex-wrap: nowrap;
+}
+
+.venues-actions-group .btn,
+.venues-actions-group form {
+  flex: 0 0 auto;
+}
+
 /* My bookings table - same styling */
 table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) {
   width: 100%;
@@ -1065,13 +1105,31 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
 /* ===== Booking Planner ===== */
 .booking-planner {
   display: grid;
-  gap: 1.25rem;
+  gap: 1rem;
   max-width: 920px;
 }
 
-.booking-planner-controls {
+.booking-config-card {
   display: grid;
   gap: 1rem;
+  padding: 1.25rem;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  background: #fff;
+  box-shadow: var(--shadow-sm);
+}
+
+.booking-config-header {
+  display: grid;
+  gap: 0.25rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--gray-200);
+}
+
+.booking-venue-title {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--primary-dark);
 }
 
 .booking-date-filter {
@@ -1082,6 +1140,18 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
   box-shadow: var(--shadow-sm);
 }
 
+.booking-date-filter-inline {
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+}
+
+.booking-date-filter-inline .booking-field {
+  max-width: 280px;
+}
+
 .booking-form {
   display: grid;
   gap: 1rem;
@@ -1090,6 +1160,13 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
   border-radius: var(--radius-lg);
   background: #fff;
   box-shadow: var(--shadow-sm);
+}
+
+.booking-form-stacked {
+  padding: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
 }
 
 .booking-field {
@@ -1180,10 +1257,12 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
 }
 
 .TimeTableTitleCellOneDayOneFacilityView {
+  width: 150px;
   padding: 0.65rem 0.85rem;
   font-weight: 700;
   background: var(--primary-bg);
   color: var(--primary-dark);
+  text-align: center;
 }
 
 .TimeTableCell_Available {
@@ -1201,12 +1280,20 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
   padding: 0.3rem 0.5rem;
 }
 
+.timetable-status-cell {
+  text-align: center;
+}
+
 .timetable-slot {
-  font-size: 0.82rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 110px;
+  font-size: 0.8rem;
   line-height: 1.35;
-  padding: 0.2rem 0.4rem;
+  padding: 0.25rem 0.5rem;
   border-radius: 4px;
-  font-weight: 500;
+  font-weight: 700;
 }
 
 .timetable-time-range {
@@ -1432,8 +1519,14 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
   .booking-time-fields {
     grid-template-columns: 1fr;
   }
+  .booking-date-filter-inline .booking-field {
+    max-width: 100%;
+  }
   .TimeTableTitleCell {
     width: 170px;
+  }
+  .venues-table {
+    min-width: 760px;
   }
 }
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1254,6 +1254,7 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
   color: var(--gray-700);
   font-size: 0.85rem;
   white-space: nowrap;
+  text-align: center;
 }
 
 .TimeTableTitleCellOneDayOneFacilityView {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1379,14 +1379,6 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
   align-items: end;
 }
 
-.approval-reject-label {
-  grid-column: 1 / -1;
-  margin: 0;
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: var(--gray-600);
-}
-
 .approval-reject-input {
   min-width: 0;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1348,29 +1348,47 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
   margin-top: 1.5rem;
 }
 
-/* ===== Inline Reject Form ===== */
-.inline-reject-form {
-  display: inline-flex;
-  align-items: center;
+/* ===== Approval Dashboard Actions ===== */
+.approval-bookings-table {
+  min-width: 1120px;
+}
+
+.approval-actions-cell {
+  min-width: 260px;
+}
+
+.approval-action-stack {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.approval-approve-form,
+.approval-reject-form {
+  margin: 0;
+}
+
+.approval-approve-button,
+.approval-reject-button {
+  width: 100%;
+}
+
+.approval-reject-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 0.4rem;
+  align-items: end;
 }
 
-.inline-reject-form input[type="text"] {
-  width: auto;
-  padding: 0.35rem 0.6rem;
-  font-size: 0.82rem;
+.approval-reject-label {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--gray-600);
 }
 
-.inline-reject-form input[type="submit"] {
-  padding: 0.35rem 0.75rem;
-  font-size: 0.82rem;
-  background: var(--danger);
-  color: #fff;
-  border-color: var(--danger);
-}
-
-.inline-reject-form input[type="submit"]:hover {
-  background: #DC2626;
+.approval-reject-input {
+  min-width: 0;
 }
 
 /* ===== Analytics Dashboard ===== */
@@ -1528,6 +1546,15 @@ table:not(.resource-grid-table):not(.TimeTable):not(.analytics-heatmap table) tb
   }
   .venues-table {
     min-width: 760px;
+  }
+  .approval-bookings-table {
+    min-width: 980px;
+  }
+  .approval-actions-cell {
+    min-width: 220px;
+  }
+  .approval-reject-form {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/app/helpers/bookings_helper.rb
+++ b/app/helpers/bookings_helper.rb
@@ -37,4 +37,15 @@ module BookingsHelper
   def booking_timetable_slot_class(slot)
     ["timetable-slot", slot[:css_class]].join(" ")
   end
+
+  def booking_timetable_status_text(slot)
+    case slot[:css_class]
+    when "timetable-slot-selected"
+      "Selected"
+    when "timetable-slot-unavailable"
+      "Unavailable"
+    else
+      "Available"
+    end
+  end
 end

--- a/app/views/bookings/_form.html.erb
+++ b/app/views/bookings/_form.html.erb
@@ -1,6 +1,15 @@
 <%= turbo_frame_tag booking_planner_frame_id, class: "booking-planner" do %>
-  <div class="booking-planner-controls">
-    <%= form_with(url: booking_date_filter_url(booking), method: :get, local: true, class: "booking-date-filter", data: { turbo_frame: booking_planner_frame_id }) do %>
+  <div class="booking-config-card">
+    <div class="booking-config-header">
+      <% if booking.venue_id.present? %>
+        <span class="booking-label">Venue</span>
+        <h3 class="booking-venue-title"><%= booking.venue&.name %></h3>
+      <% else %>
+        <h3 class="booking-venue-title">Choose a venue and time</h3>
+      <% end %>
+    </div>
+
+    <%= form_with(url: booking_date_filter_url(booking), method: :get, local: true, class: "booking-date-filter booking-date-filter-inline", data: { turbo_frame: booking_planner_frame_id }) do %>
       <%= hidden_field_tag :venue_id, booking.venue_id || params[:venue_id] %>
       <div class="booking-field">
         <%= label_tag :booking_date, "Booking date", class: "booking-label" %>
@@ -19,7 +28,7 @@
             booking_time_day_end_value: "22:00",
             booking_time_max_hours_value: 4
           },
-          class: "booking-form"
+          class: "booking-form booking-form-stacked"
         ) do |form| %>
       <% if booking.errors.any? %>
         <div class="booking-errors">
@@ -31,16 +40,14 @@
         </div>
       <% end %>
 
-      <div class="booking-field booking-resource-summary">
-        <% if booking.venue_id %>
-          <%= form.hidden_field :venue_id %>
-          <span class="booking-label">Venue</span>
-          <span><%= booking.venue&.name %></span>
-        <% else %>
+      <% if booking.venue_id.present? %>
+        <%= form.hidden_field :venue_id %>
+      <% else %>
+        <div class="booking-field">
           <%= form.label :venue_id, class: "booking-label" %>
           <%= form.collection_select :venue_id, (@venues || Venue.none), :id, :name %>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
 
       <%= hidden_field_tag "booking[booking_date]", @booking_date %>
 
@@ -63,7 +70,7 @@
   </div>
 
   <%= render "timetable", booking: booking %>
-  <p class="timetable-note">Tip: use the timetable below to verify availability before submitting.</p>
+  <p class="timetable-note">Tip: review the timetable above before submitting your booking.</p>
   <% unless booking.persisted? %>
     <p class="timetable-note">After selecting times, click "<%= booking_submit_label(booking) %>" to continue.</p>
   <% end %>

--- a/app/views/bookings/_form.html.erb
+++ b/app/views/bookings/_form.html.erb
@@ -1,62 +1,70 @@
 <%= turbo_frame_tag booking_planner_frame_id, class: "booking-planner" do %>
-  <%= form_with(url: booking_date_filter_url(booking), method: :get, local: true, class: "booking-date-filter", data: { turbo_frame: booking_planner_frame_id }) do %>
-    <%= hidden_field_tag :venue_id, booking.venue_id || params[:venue_id] %>
-    <div class="booking-field">
-      <%= label_tag :booking_date, "Booking date", class: "booking-label" %>
-      <%= date_field_tag :booking_date, @booking_date, required: true, min: booking_date_minimum, onchange: "this.form.requestSubmit();" %>
-    </div>
-  <% end %>
-
-  <%= render "timetable", booking: booking %>
-
-  <%= form_with(
-        model: booking,
-        url: booking_form_url(booking),
-        method: booking_form_method(booking),
-        data: {
-          turbo: false,
-          controller: "booking-time",
-          booking_time_unavailable_ranges_value: @unavailable_ranges_for_slots.map { |b| { start: b.start_time.strftime('%H:%M'), end: b.end_time.strftime('%H:%M') } }.to_json,
-          booking_time_day_end_value: "22:00",
-          booking_time_max_hours_value: 4
-        },
-        class: "booking-form"
-      ) do |form| %>
-    <% if booking.errors.any? %>
-      <div class="booking-errors">
-        <ul class="booking-error-list">
-          <% booking.errors.each do |error| %>
-            <li><%= error.full_message %></li>
-          <% end %>
-        </ul>
+  <div class="booking-planner-controls">
+    <%= form_with(url: booking_date_filter_url(booking), method: :get, local: true, class: "booking-date-filter", data: { turbo_frame: booking_planner_frame_id }) do %>
+      <%= hidden_field_tag :venue_id, booking.venue_id || params[:venue_id] %>
+      <div class="booking-field">
+        <%= label_tag :booking_date, "Booking date", class: "booking-label" %>
+        <%= date_field_tag :booking_date, @booking_date, required: true, min: booking_date_minimum, onchange: "this.form.requestSubmit();" %>
       </div>
     <% end %>
 
-    <div class="booking-field booking-resource-summary">
-      <% if booking.venue_id %>
-        <%= form.hidden_field :venue_id %>
-        <span class="booking-label">Venue</span>
-        <span><%= booking.venue&.name %></span>
-      <% else %>
-        <%= form.label :venue_id, class: "booking-label" %>
-        <%= form.collection_select :venue_id, (@venues || Venue.none), :id, :name %>
+    <%= form_with(
+          model: booking,
+          url: booking_form_url(booking),
+          method: booking_form_method(booking),
+          data: {
+            turbo: false,
+            controller: "booking-time",
+            booking_time_unavailable_ranges_value: @unavailable_ranges_for_slots.map { |b| { start: b.start_time.strftime('%H:%M'), end: b.end_time.strftime('%H:%M') } }.to_json,
+            booking_time_day_end_value: "22:00",
+            booking_time_max_hours_value: 4
+          },
+          class: "booking-form"
+        ) do |form| %>
+      <% if booking.errors.any? %>
+        <div class="booking-errors">
+          <ul class="booking-error-list">
+            <% booking.errors.each do |error| %>
+              <li><%= error.full_message %></li>
+            <% end %>
+          </ul>
+        </div>
       <% end %>
-    </div>
 
-    <%= hidden_field_tag "booking[booking_date]", @booking_date %>
+      <div class="booking-field booking-resource-summary">
+        <% if booking.venue_id %>
+          <%= form.hidden_field :venue_id %>
+          <span class="booking-label">Venue</span>
+          <span><%= booking.venue&.name %></span>
+        <% else %>
+          <%= form.label :venue_id, class: "booking-label" %>
+          <%= form.collection_select :venue_id, (@venues || Venue.none), :id, :name %>
+        <% end %>
+      </div>
 
-    <div class="booking-field">
-      <%= label_tag "booking_start_slot", "Start time", class: "booking-label" %>
-      <%= select_tag "booking[start_slot]", options_for_select(@start_slot_options, booking.start_time&.strftime('%H:%M')), include_blank: "Select start time", id: "booking_start_slot", data: { booking_time_target: "startSelect", action: "change->booking-time#startChanged" } %>
-    </div>
+      <%= hidden_field_tag "booking[booking_date]", @booking_date %>
 
-    <div class="booking-field">
-      <%= label_tag "booking_end_slot", "End time", class: "booking-label" %>
-      <%= select_tag "booking[end_slot]", options_for_select(@end_slot_options, booking.end_time&.strftime('%H:%M')), include_blank: "Select end time", id: "booking_end_slot", disabled: booking.start_time.blank?, data: { booking_time_target: "endSelect" } %>
-    </div>
+      <div class="booking-time-fields">
+        <div class="booking-field">
+          <%= label_tag "booking_start_slot", "Start time", class: "booking-label" %>
+          <%= select_tag "booking[start_slot]", options_for_select(@start_slot_options, booking.start_time&.strftime('%H:%M')), include_blank: "Select start time", id: "booking_start_slot", data: { booking_time_target: "startSelect", action: "change->booking-time#startChanged" } %>
+        </div>
 
-    <div class="booking-actions">
-      <%= form.submit booking_submit_label(booking), class: "button-primary" %>
-    </div>
+        <div class="booking-field">
+          <%= label_tag "booking_end_slot", "End time", class: "booking-label" %>
+          <%= select_tag "booking[end_slot]", options_for_select(@end_slot_options, booking.end_time&.strftime('%H:%M')), include_blank: "Select end time", id: "booking_end_slot", disabled: booking.start_time.blank?, data: { booking_time_target: "endSelect" } %>
+        </div>
+      </div>
+
+      <div class="booking-actions">
+        <%= form.submit booking_submit_label(booking), class: "button-primary" %>
+      </div>
+    <% end %>
+  </div>
+
+  <%= render "timetable", booking: booking %>
+  <p class="timetable-note">Tip: use the timetable below to verify availability before submitting.</p>
+  <% unless booking.persisted? %>
+    <p class="timetable-note">After selecting times, click "<%= booking_submit_label(booking) %>" to continue.</p>
   <% end %>
 <% end %>

--- a/app/views/bookings/_timetable.html.erb
+++ b/app/views/bookings/_timetable.html.erb
@@ -8,7 +8,7 @@
   <thead>
     <tr>
       <th scope="col" class="TimeTableTitleCell">Time Slot</th>
-      <th scope="col" class="TimeTableTitleCellOneDayOneFacilityView"><%= booking.venue&.name || 'Select a venue' %></th>
+      <th scope="col" class="TimeTableTitleCellOneDayOneFacilityView">Availability</th>
     </tr>
   </thead>
   <tbody>
@@ -17,10 +17,10 @@
         <td class="TimeTableTitleCell timetable-time-cell">
           <span class="timetable-time-range"><%= slot[:start_at].strftime('%I:%M %p') %> - <%= slot[:end_at].strftime('%I:%M %p') %></span>
         </td>
-        <td class="<%= booking_timetable_cell_class(slot) %>">
-          <div class="<%= booking_timetable_slot_class(slot) %>" data-slot-start="<%= slot[:start_at].strftime('%Y-%m-%dT%H:%M') %>" data-slot-end="<%= slot[:end_at].strftime('%Y-%m-%dT%H:%M') %>">
-            <%= slot[:label] %>
-          </div>
+        <td class="<%= booking_timetable_cell_class(slot) %> timetable-status-cell">
+          <span class="<%= booking_timetable_slot_class(slot) %>">
+            <%= booking_timetable_status_text(slot) %>
+          </span>
         </td>
       </tr>
     <% end %>

--- a/app/views/bookings/_timetable.html.erb
+++ b/app/views/bookings/_timetable.html.erb
@@ -1,5 +1,3 @@
-<p><strong>Selected date:</strong> <%= @booking_date %></p>
-
 <div class="timetable-legend">
   <span class="timetable-chip timetable-slot-unavailable">Unavailable</span>
   <span class="timetable-chip timetable-slot-selected">Selected</span>
@@ -9,15 +7,15 @@
 <table class="TimeTable" cellspacing="0" cellpadding="0" border="1">
   <thead>
     <tr>
-      <td class="TimeTableTitleCell"><%= @booking_date.strftime('%d %b %Y') %></td>
-      <td class="TimeTableTitleCellOneDayOneFacilityView"><%= booking.venue&.name || 'Select a venue' %></td>
+      <th scope="col" class="TimeTableTitleCell">Time Slot</th>
+      <th scope="col" class="TimeTableTitleCellOneDayOneFacilityView"><%= booking.venue&.name || 'Select a venue' %></th>
     </tr>
   </thead>
   <tbody>
     <% @timetable_slots.each do |slot| %>
       <tr>
-        <td class="TimeTableTitleCell">
-          <span><%= slot[:start_at].strftime('%I:%M %p') %>- <%= slot[:end_at].strftime('%I:%M %p') %></span>
+        <td class="TimeTableTitleCell timetable-time-cell">
+          <span class="timetable-time-range"><%= slot[:start_at].strftime('%I:%M %p') %> - <%= slot[:end_at].strftime('%I:%M %p') %></span>
         </td>
         <td class="<%= booking_timetable_cell_class(slot) %>">
           <div class="<%= booking_timetable_slot_class(slot) %>" data-slot-start="<%= slot[:start_at].strftime('%Y-%m-%dT%H:%M') %>" data-slot-end="<%= slot[:end_at].strftime('%Y-%m-%dT%H:%M') %>">

--- a/app/views/dashboards/approvals.html.erb
+++ b/app/views/dashboards/approvals.html.erb
@@ -13,106 +13,120 @@
   <% if venue_bookings.any? %>
     <h2 class="mb-1">Venue Approvals</h2>
     <div class="card mb-2">
-      <table id="approvals-table" class="resource-grid-table" style="margin:0;border:none;box-shadow:none;">
-        <thead>
-          <tr>
-            <th><%= sortable_header_link("Venue", "venue", current_sort: @sort_column, current_direction: @sort_direction) %></th>
-            <th><%= sortable_header_link("Department", "department", current_sort: @sort_column, current_direction: @sort_direction) %></th>
-            <th><%= sortable_header_link("User", "user", current_sort: @sort_column, current_direction: @sort_direction) %></th>
-            <th><%= sortable_header_link("Date", "date", current_sort: @sort_column, current_direction: @sort_direction) %></th>
-            <th><%= sortable_header_link("Status", "status", current_sort: @sort_column, current_direction: @sort_direction) %></th>
-            <th>Last Action</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% venue_bookings.each do |booking| %>
-            <tr id="<%= dom_id(booking) %>">
-              <td><strong><%= booking.venue&.name || "-" %></strong></td>
-              <td><span class="badge badge-role"><%= booking.venue&.department || booking.user&.tenant&.name || "-" %></span></td>
-              <td class="text-muted"><%= booking.user.email %></td>
-              <td><%= booking.start_time&.to_date || "-" %></td>
-              <td>
-                <%= status_badge(booking.status) %>
-                <% if booking.under_review? && booking.user&.tenant&.two_step? %>
-                  <span class="badge badge-under-review">Step 1/2</span>
-                <% end %>
-              </td>
-              <td class="text-muted text-sm">
-                <% latest_step = booking.approval_steps.max_by(&:created_at) %>
-                <% if latest_step.present? %>
-                  <%= "#{latest_step.action.humanize} by #{latest_step.actor.email}" %>
-                <% else %>
-                  -
-                <% end %>
-              </td>
-              <td>
-                <div class="btn-group">
-                  <%= button_to(booking.under_review? ? "Approve (Final)" : "Approve", approve_booking_path(booking), method: :patch, class: "btn btn-success btn-sm") %>
-                  <%= form_with url: reject_booking_path(booking), method: :patch, local: true, class: "inline-reject-form" do |f| %>
-                    <%= f.text_field :rejection_reason, placeholder: "Reason", size: 18 %>
-                    <%= f.submit "Reject" %>
-                  <% end %>
-                </div>
-              </td>
+      <div class="table-scroll-shell">
+        <table id="approvals-table" class="resource-grid-table approval-bookings-table" style="margin:0;border:none;box-shadow:none;">
+          <thead>
+            <tr>
+              <th><%= sortable_header_link("Venue", "venue", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+              <th><%= sortable_header_link("Department", "department", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+              <th><%= sortable_header_link("User", "user", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+              <th><%= sortable_header_link("Date", "date", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+              <th><%= sortable_header_link("Status", "status", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+              <th>Last Action</th>
+              <th>Actions</th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            <% venue_bookings.each do |booking| %>
+              <tr id="<%= dom_id(booking) %>">
+                <td><strong><%= booking.venue&.name || "-" %></strong></td>
+                <td><span class="badge badge-role"><%= booking.venue&.department || booking.user&.tenant&.name || "-" %></span></td>
+                <td class="text-muted"><%= booking.user.email %></td>
+                <td><%= booking.start_time&.to_date || "-" %></td>
+                <td>
+                  <%= status_badge(booking.status) %>
+                  <% if booking.under_review? && booking.user&.tenant&.two_step? %>
+                    <span class="badge badge-under-review">Step 1/2</span>
+                  <% end %>
+                </td>
+                <td class="text-muted text-sm">
+                  <% latest_step = booking.approval_steps.max_by(&:created_at) %>
+                  <% if latest_step.present? %>
+                    <%= "#{latest_step.action.humanize} by #{latest_step.actor.email}" %>
+                  <% else %>
+                    -
+                  <% end %>
+                </td>
+                <td class="approval-actions-cell">
+                  <div class="approval-action-stack">
+                    <%= button_to(booking.under_review? ? "Approve (Final)" : "Approve",
+                                  approve_booking_path(booking),
+                                  method: :patch,
+                                  class: "btn btn-success btn-sm approval-approve-button",
+                                  form: { class: "approval-approve-form" }) %>
+                    <%= form_with url: reject_booking_path(booking), method: :patch, local: true, class: "approval-reject-form" do |f| %>
+                      <%= f.label :rejection_reason, "Reason", class: "approval-reject-label" %>
+                      <%= f.text_field :rejection_reason, placeholder: "Reason for rejection", required: true, class: "approval-reject-input" %>
+                      <%= f.submit "Reject", class: "btn btn-danger btn-sm approval-reject-button" %>
+                    <% end %>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
   <% end %>
 
   <% if equipment_bookings.any? %>
     <h2 class="mb-1">Equipment Approvals</h2>
     <div class="card mb-2">
-      <table id="approvals-equipment-table" class="resource-grid-table" style="margin:0;border:none;box-shadow:none;">
-        <thead>
-          <tr>
-            <th><%= sortable_header_link("Equipment", "venue", current_sort: @sort_column, current_direction: @sort_direction) %></th>
-            <th><%= sortable_header_link("Department", "department", current_sort: @sort_column, current_direction: @sort_direction) %></th>
-            <th><%= sortable_header_link("User", "user", current_sort: @sort_column, current_direction: @sort_direction) %></th>
-            <th>Qty</th>
-            <th><%= sortable_header_link("Date", "date", current_sort: @sort_column, current_direction: @sort_direction) %></th>
-            <th><%= sortable_header_link("Status", "status", current_sort: @sort_column, current_direction: @sort_direction) %></th>
-            <th>Last Action</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% equipment_bookings.each do |booking| %>
-            <tr id="<%= dom_id(booking) %>">
-              <td><strong><%= booking.equipment&.name || "-" %></strong></td>
-              <td><span class="badge badge-role"><%= booking.equipment&.tenant&.name || booking.user&.tenant&.name || "-" %></span></td>
-              <td class="text-muted"><%= booking.user.email %></td>
-              <td><%= booking.quantity || "-" %></td>
-              <td><%= booking.start_date || "-" %></td>
-              <td>
-                <%= status_badge(booking.status) %>
-                <% if booking.under_review? && booking.user&.tenant&.two_step? %>
-                  <span class="badge badge-under-review">Step 1/2</span>
-                <% end %>
-              </td>
-              <td class="text-muted text-sm">
-                <% latest_step = booking.approval_steps.max_by(&:created_at) %>
-                <% if latest_step.present? %>
-                  <%= "#{latest_step.action.humanize} by #{latest_step.actor.email}" %>
-                <% else %>
-                  -
-                <% end %>
-              </td>
-              <td>
-                <div class="btn-group">
-                  <%= button_to(booking.under_review? ? "Approve (Final)" : "Approve", approve_booking_path(booking), method: :patch, class: "btn btn-success btn-sm") %>
-                  <%= form_with url: reject_booking_path(booking), method: :patch, local: true, class: "inline-reject-form" do |f| %>
-                    <%= f.text_field :rejection_reason, placeholder: "Reason", size: 18 %>
-                    <%= f.submit "Reject" %>
-                  <% end %>
-                </div>
-              </td>
+      <div class="table-scroll-shell">
+        <table id="approvals-equipment-table" class="resource-grid-table approval-bookings-table" style="margin:0;border:none;box-shadow:none;">
+          <thead>
+            <tr>
+              <th><%= sortable_header_link("Equipment", "venue", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+              <th><%= sortable_header_link("Department", "department", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+              <th><%= sortable_header_link("User", "user", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+              <th>Qty</th>
+              <th><%= sortable_header_link("Date", "date", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+              <th><%= sortable_header_link("Status", "status", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+              <th>Last Action</th>
+              <th>Actions</th>
             </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            <% equipment_bookings.each do |booking| %>
+              <tr id="<%= dom_id(booking) %>">
+                <td><strong><%= booking.equipment&.name || "-" %></strong></td>
+                <td><span class="badge badge-role"><%= booking.equipment&.tenant&.name || booking.user&.tenant&.name || "-" %></span></td>
+                <td class="text-muted"><%= booking.user.email %></td>
+                <td><%= booking.quantity || "-" %></td>
+                <td><%= booking.start_date || "-" %></td>
+                <td>
+                  <%= status_badge(booking.status) %>
+                  <% if booking.under_review? && booking.user&.tenant&.two_step? %>
+                    <span class="badge badge-under-review">Step 1/2</span>
+                  <% end %>
+                </td>
+                <td class="text-muted text-sm">
+                  <% latest_step = booking.approval_steps.max_by(&:created_at) %>
+                  <% if latest_step.present? %>
+                    <%= "#{latest_step.action.humanize} by #{latest_step.actor.email}" %>
+                  <% else %>
+                    -
+                  <% end %>
+                </td>
+                <td class="approval-actions-cell">
+                  <div class="approval-action-stack">
+                    <%= button_to(booking.under_review? ? "Approve (Final)" : "Approve",
+                                  approve_booking_path(booking),
+                                  method: :patch,
+                                  class: "btn btn-success btn-sm approval-approve-button",
+                                  form: { class: "approval-approve-form" }) %>
+                    <%= form_with url: reject_booking_path(booking), method: :patch, local: true, class: "approval-reject-form" do |f| %>
+                      <%= f.label :rejection_reason, "Reason", class: "approval-reject-label" %>
+                      <%= f.text_field :rejection_reason, placeholder: "Reason for rejection", required: true, class: "approval-reject-input" %>
+                      <%= f.submit "Reject", class: "btn btn-danger btn-sm approval-reject-button" %>
+                    <% end %>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
   <% end %>
 

--- a/app/views/dashboards/approvals.html.erb
+++ b/app/views/dashboards/approvals.html.erb
@@ -55,8 +55,7 @@
                                   class: "btn btn-success btn-sm approval-approve-button",
                                   form: { class: "approval-approve-form" }) %>
                     <%= form_with url: reject_booking_path(booking), method: :patch, local: true, class: "approval-reject-form" do |f| %>
-                      <%= f.label :rejection_reason, "Reason", class: "approval-reject-label" %>
-                      <%= f.text_field :rejection_reason, placeholder: "Reason for rejection", required: true, class: "approval-reject-input" %>
+                      <%= f.text_field :rejection_reason, placeholder: "Reason for rejection", required: true, class: "approval-reject-input", aria: { label: "Reason" } %>
                       <%= f.submit "Reject", class: "btn btn-danger btn-sm approval-reject-button" %>
                     <% end %>
                   </div>
@@ -116,8 +115,7 @@
                                   class: "btn btn-success btn-sm approval-approve-button",
                                   form: { class: "approval-approve-form" }) %>
                     <%= form_with url: reject_booking_path(booking), method: :patch, local: true, class: "approval-reject-form" do |f| %>
-                      <%= f.label :rejection_reason, "Reason", class: "approval-reject-label" %>
-                      <%= f.text_field :rejection_reason, placeholder: "Reason for rejection", required: true, class: "approval-reject-input" %>
+                      <%= f.text_field :rejection_reason, placeholder: "Reason for rejection", required: true, class: "approval-reject-input", aria: { label: "Reason" } %>
                       <%= f.submit "Reject", class: "btn btn-danger btn-sm approval-reject-button" %>
                     <% end %>
                   </div>

--- a/app/views/venue_requests/index.html.erb
+++ b/app/views/venue_requests/index.html.erb
@@ -27,38 +27,40 @@
 
 <% if @venue_requests.any? %>
   <div class="card">
-    <table class="resource-grid-table" style="margin:0; border:none; box-shadow:none;">
-      <thead>
-        <tr>
-          <th>Venue Name</th>
-          <th>Description</th>
-          <% if current_user.admin? %><th>Requested By</th><% end %>
-          <th>College</th>
-          <th>Status</th>
-          <% if current_user.admin? %><th>Requested At</th><% end %>
-          <% if current_user.admin? %><th>Reviewed By</th><% end %>
-          <% if current_user.admin? %><th>Reviewed At</th><% end %>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @venue_requests.each do |request| %>
-          <tr<%= ' style="background-color: rgba(255, 243, 205, 0.45);"' if request.pending? %>>
-            <td><strong><%= request.venue_name %></strong></td>
-            <td class="text-muted"><%= request.description %></td>
-            <% if current_user.admin? %><td><%= request.requester.email %></td><% end %>
-            <td><span class="badge badge-role"><%= request.tenant.name %></span></td>
-            <td><%= status_badge(request.status) %></td>
-            <% if current_user.admin? %><td class="text-muted"><%= request.created_at.strftime("%Y-%m-%d %H:%M") %></td><% end %>
-            <% if current_user.admin? %><td><%= request.reviewed_by&.email || "-" %></td><% end %>
-            <% if current_user.admin? %><td class="text-muted"><%= request.reviewed_at&.strftime("%Y-%m-%d %H:%M") || "-" %></td><% end %>
-            <td>
-              <%= link_to "View", venue_request_path(request, status: @status_filter), class: "btn btn-secondary btn-sm" %>
-            </td>
+    <div class="table-scroll-shell">
+      <table class="resource-grid-table venue-requests-table" style="margin:0; border:none; box-shadow:none;">
+        <thead>
+          <tr>
+            <th>Venue Name</th>
+            <th>Description</th>
+            <% if current_user.admin? %><th>Requested By</th><% end %>
+            <th>College</th>
+            <th>Status</th>
+            <% if current_user.admin? %><th>Requested At</th><% end %>
+            <% if current_user.admin? %><th>Reviewed By</th><% end %>
+            <% if current_user.admin? %><th>Reviewed At</th><% end %>
+            <th class="venue-request-actions-header">Actions</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% @venue_requests.each do |request| %>
+            <tr<%= ' style="background-color: rgba(255, 243, 205, 0.45);"' if request.pending? %>>
+              <td><strong><%= request.venue_name %></strong></td>
+              <td class="text-muted venue-request-description"><%= request.description.presence || "-" %></td>
+              <% if current_user.admin? %><td class="venue-request-email"><%= request.requester.email %></td><% end %>
+              <td><span class="badge badge-role"><%= request.tenant.name %></span></td>
+              <td><%= status_badge(request.status) %></td>
+              <% if current_user.admin? %><td class="text-muted"><%= request.created_at.strftime("%Y-%m-%d %H:%M") %></td><% end %>
+              <% if current_user.admin? %><td><%= request.reviewed_by&.email || "-" %></td><% end %>
+              <% if current_user.admin? %><td class="text-muted"><%= request.reviewed_at&.strftime("%Y-%m-%d %H:%M") || "-" %></td><% end %>
+              <td class="venue-request-actions">
+                <%= link_to "View", venue_request_path(request, status: @status_filter), class: "btn btn-secondary btn-sm" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
 <% else %>
   <div class="empty-state">

--- a/app/views/venue_requests/show.html.erb
+++ b/app/views/venue_requests/show.html.erb
@@ -58,21 +58,31 @@
   <div class="card">
     <div class="card-body">
       <h3 class="mb-2">Review Actions</h3>
-      <div class="btn-group mb-2">
-        <%= button_to "Approve",
-                      approve_venue_request_path(@venue_request, status: @return_status),
-                      method: :patch,
-                      class: "btn btn-primary btn-sm",
-                      data: { turbo_confirm: "Approve this venue request?" } %>
-      </div>
+      <div class="venue-request-review-grid">
+        <section class="venue-request-review-action venue-request-approve-action">
+          <h4>Approve request</h4>
+          <p class="text-muted text-sm">This will approve the request and create the venue immediately.</p>
+          <%= button_to "Approve",
+                        approve_venue_request_path(@venue_request, status: @return_status),
+                        method: :patch,
+                        class: "btn btn-success btn-sm venue-request-review-button",
+                        form: { class: "venue-request-action-form" },
+                        data: { turbo_confirm: "Approve this venue request?" } %>
+        </section>
 
-      <%= form_with url: reject_venue_request_path(@venue_request, status: @return_status), method: :patch, local: true do |f| %>
-        <div class="form-group">
-          <%= f.label :rejection_reason, "Rejection reason" %>
-          <%= f.text_field :rejection_reason, required: true, placeholder: "Reason for rejection" %>
-        </div>
-        <%= f.submit "Reject", class: "btn btn-danger btn-sm", data: { turbo_confirm: "Reject this venue request?" } %>
-      <% end %>
+        <section class="venue-request-review-action venue-request-reject-action">
+          <h4>Reject request</h4>
+          <p class="text-muted text-sm">Rejecting requires a reason so staff know what to update.</p>
+
+          <%= form_with url: reject_venue_request_path(@venue_request, status: @return_status), method: :patch, local: true, class: "venue-request-reject-form" do |f| %>
+            <div class="form-group">
+              <%= f.label :rejection_reason, "Rejection reason" %>
+              <%= f.text_field :rejection_reason, required: true, placeholder: "Reason for rejection" %>
+            </div>
+            <%= f.submit "Reject", class: "btn btn-danger btn-sm venue-request-review-button", data: { turbo_confirm: "Reject this venue request?" } %>
+          <% end %>
+        </section>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/venues/index.html.erb
+++ b/app/views/venues/index.html.erb
@@ -13,37 +13,39 @@
 
 <% if @venues.any? %>
   <div class="card">
-    <table id="venues-table" class="resource-grid-table" style="margin:0; border:none; box-shadow:none;">
-      <thead>
-        <tr>
-          <th><%= sortable_header_link("Name", "name", current_sort: @sort_column, current_direction: @sort_direction) %></th>
-          <th><%= sortable_header_link("Description", "description", current_sort: @sort_column, current_direction: @sort_direction) %></th>
-          <th><%= sortable_header_link("Department", "department", current_sort: @sort_column, current_direction: @sort_direction) %></th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @venues.each do |venue| %>
+    <div class="table-scroll-shell">
+      <table id="venues-table" class="resource-grid-table venues-table" style="margin:0; border:none; box-shadow:none;">
+        <thead>
           <tr>
-            <td><strong><%= link_to venue.name, venue_path(venue) %></strong></td>
-            <td class="text-muted"><%= venue.description %></td>
-            <td><span class="badge badge-role"><%= venue.department %></span></td>
-            <td>
-              <div class="btn-group">
-                <%= link_to "View", venue_path(venue), class: "btn btn-outline btn-sm" %>
-                <% if current_user&.student? %>
-                  <%= link_to "Book", new_booking_path(venue_id: venue.id), class: "btn btn-primary btn-sm" %>
-                <% end %>
-                <% if current_user&.admin? || current_user&.staff? %>
-                  <%= link_to "Edit", edit_venue_path(venue), class: "btn btn-secondary btn-sm" %>
-                  <%= button_to "Delete", venue_path(venue), method: :delete, class: "btn btn-danger btn-sm", form: { style: "display:inline" }, data: { turbo_confirm: "Delete this venue?" } %>
-                <% end %>
-              </div>
-            </td>
+            <th class="venues-col-name"><%= sortable_header_link("Name", "name", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+            <th class="venues-col-description"><%= sortable_header_link("Description", "description", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+            <th class="venues-col-department"><%= sortable_header_link("Department", "department", current_sort: @sort_column, current_direction: @sort_direction) %></th>
+            <th class="venues-col-actions">Actions</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% @venues.each do |venue| %>
+            <tr>
+              <td class="venues-col-name"><strong><%= link_to venue.name, venue_path(venue) %></strong></td>
+              <td class="text-muted venues-col-description"><%= venue.description %></td>
+              <td class="venues-col-department"><span class="badge badge-role"><%= venue.department %></span></td>
+              <td class="venues-col-actions">
+                <div class="btn-group venues-actions-group">
+                  <%= link_to "View", venue_path(venue), class: "btn btn-outline btn-sm" %>
+                  <% if current_user&.student? %>
+                    <%= link_to "Book", new_booking_path(venue_id: venue.id), class: "btn btn-primary btn-sm" %>
+                  <% end %>
+                  <% if current_user&.admin? || current_user&.staff? %>
+                    <%= link_to "Edit", edit_venue_path(venue), class: "btn btn-secondary btn-sm" %>
+                    <%= button_to "Delete", venue_path(venue), method: :delete, class: "btn btn-danger btn-sm", form: { style: "display:inline" }, data: { turbo_confirm: "Delete this venue?" } %>
+                  <% end %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
 <% else %>
   <div class="empty-state">

--- a/features/step_definitions/approval_workflow_steps.rb
+++ b/features/step_definitions/approval_workflow_steps.rb
@@ -138,7 +138,7 @@ When("I reject the booking for {string} on {string} with reason {string}") do |v
   @current_booking = booking
 
   within("##{ActionView::RecordIdentifier.dom_id(booking)}") do
-    fill_in "Reason", with: reason
+    fill_in "rejection_reason", with: reason
     click_button "Reject"
   end
 end

--- a/features/step_definitions/booking_timetable_steps.rb
+++ b/features/step_definitions/booking_timetable_steps.rb
@@ -26,12 +26,12 @@ When('I open the edit booking page for my booking on a date {int} days in the fu
 end
 
 Then('I should see timetable date {string}') do |date|
-  expect(page).to have_content("Selected date: #{date}")
+  expect(find('#booking_date', visible: :all).value).to eq(date)
 end
 
 Then('I should see timetable date for {int} days in the future') do |days|
   date = (Date.current + days.days).strftime('%Y-%m-%d')
-  expect(page).to have_content("Selected date: #{date}")
+  expect(find('#booking_date', visible: :all).value).to eq(date)
 end
 
 Given('there is a booking for {string} by {string} from {int} days in the future at {string} to {int} days in the future at {string}') do |venue_name, user_email, start_days, start_time, end_days, end_time|

--- a/features/step_definitions/booking_timetable_steps.rb
+++ b/features/step_definitions/booking_timetable_steps.rb
@@ -50,19 +50,23 @@ Given('there is a booking for {string} by {string} from {int} days in the future
 end
 
 Then('the slot {string} should be marked unavailable') do |label|
-  expect(page).to have_css('.timetable-slot.timetable-slot-unavailable', text: label)
+  row = find_timetable_row(label)
+  expect(row).to have_css('.timetable-slot.timetable-slot-unavailable', text: 'Unavailable')
 end
 
 Then('the slot {string} should be marked available') do |label|
-  expect(page).to have_css('.timetable-slot.timetable-slot-available', text: label)
+  row = find_timetable_row(label)
+  expect(row).to have_css('.timetable-slot.timetable-slot-available', text: 'Available')
 end
 
 Then('the slot {string} should be marked selected') do |label|
-  expect(page).to have_css('.timetable-slot.timetable-slot-selected', text: label)
+  row = find_timetable_row(label)
+  expect(row).to have_css('.timetable-slot.timetable-slot-selected', text: 'Selected')
 end
 
 Then('the slot {string} should not be marked selected') do |label|
-  expect(page).not_to have_css('.timetable-slot.timetable-slot-selected', text: label)
+  row = find_timetable_row(label)
+  expect(row).not_to have_css('.timetable-slot.timetable-slot-selected')
 end
 
 Then('the {string} options should include:') do |field_label, table|
@@ -87,4 +91,10 @@ end
 
 Then('the end time picker should be enabled') do
   expect(find('#booking_end_slot', visible: :all)).not_to be_disabled
+end
+
+def find_timetable_row(label)
+  start_at, end_at = label.split(/\s*-\s*/, 2).map(&:strip)
+  display_label = "#{Time.zone.parse(start_at).strftime('%I:%M %p')} - #{Time.zone.parse(end_at).strftime('%I:%M %p')}"
+  find('table.TimeTable tbody tr', text: display_label)
 end

--- a/spec/helpers/bookings_helper_spec.rb
+++ b/spec/helpers/bookings_helper_spec.rb
@@ -8,4 +8,24 @@ RSpec.describe BookingsHelper, type: :helper do
   it "is included in the helper object" do
     expect(helper).to be_a(described_class)
   end
+
+  describe "#booking_timetable_status_text" do
+    it "returns selected for selected slots" do
+      slot = { css_class: "timetable-slot-selected" }
+
+      expect(helper.booking_timetable_status_text(slot)).to eq("Selected")
+    end
+
+    it "returns unavailable for blocked slots" do
+      slot = { css_class: "timetable-slot-unavailable" }
+
+      expect(helper.booking_timetable_status_text(slot)).to eq("Unavailable")
+    end
+
+    it "defaults to available for open slots" do
+      slot = { css_class: "timetable-slot-available" }
+
+      expect(helper.booking_timetable_status_text(slot)).to eq("Available")
+    end
+  end
 end

--- a/spec/requests/bookings_spec.rb
+++ b/spec/requests/bookings_spec.rb
@@ -128,6 +128,21 @@ RSpec.describe "/bookings", type: :request do
       expect(response).to be_successful
     end
 
+    it "shows compact booking controls and a readable timetable time column" do
+      booking_date = 5.days.from_now.to_date
+
+      get new_booking_url, params: { venue_id: venue.id, booking_date: booking_date.to_s }
+
+      document = Nokogiri::HTML(response.body)
+      booking_date_input = document.at_css('input#booking_date')
+
+      expect(response.body).to include('booking-time-fields')
+      expect(response.body).to include('Time Slot')
+      expect(response.body).not_to include('Selected date:')
+      expect(booking_date_input).not_to be_nil
+      expect(booking_date_input['value']).to eq(booking_date.to_s)
+    end
+
     it "excludes unavailable start slots" do
       booking_date = 5.days.from_now.to_date
       other_user = create(:user, tenant: tenant, email: "other-student@link.cuhk.edu.hk")

--- a/spec/requests/bookings_spec.rb
+++ b/spec/requests/bookings_spec.rb
@@ -397,6 +397,9 @@ RSpec.describe "/bookings", type: :request do
       expect(response.body).to include("Room 102")
       expect(response.body).not_to include("Room 103")
       expect(response.body).not_to include("LT1")
+      expect(response.body).to include("approval-action-stack")
+      expect(response.body).to include("approval-reject-form")
+      expect(response.body).to include("Reason for rejection")
     end
 
     it "keeps legacy venues visible when department matches tenant name" do

--- a/spec/requests/bookings_spec.rb
+++ b/spec/requests/bookings_spec.rb
@@ -136,9 +136,13 @@ RSpec.describe "/bookings", type: :request do
       document = Nokogiri::HTML(response.body)
       booking_date_input = document.at_css('input#booking_date')
 
+      expect(response.body).to include('booking-config-card')
+      expect(response.body).to include('booking-date-filter-inline')
       expect(response.body).to include('booking-time-fields')
       expect(response.body).to include('Time Slot')
-      expect(response.body).not_to include('Selected date:')
+      expect(response.body).to include('Availability')
+      expect(response.body).to include('review the timetable above')
+      expect(response.body).not_to include('timetable below')
       expect(booking_date_input).not_to be_nil
       expect(booking_date_input['value']).to eq(booking_date.to_s)
     end
@@ -284,7 +288,8 @@ RSpec.describe "/bookings", type: :request do
 
       expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include('Booking duration cannot exceed 4 hours')
-      expect(response.body).not_to match(/timetable-slot-selected[^>]*>\s*08:00 - 09:00/m)
+      document = Nokogiri::HTML(response.body)
+      expect(document.css('.timetable-slot.timetable-slot-selected')).to be_empty
     end
   end
 

--- a/spec/requests/venue_requests_spec.rb
+++ b/spec/requests/venue_requests_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe 'Venue Requests', type: :request do
       expect(response.body).to include('Reviewed By')
       expect(response.body).to include('Reviewed At')
       expect(response.body).to include('View')
+      expect(response.body).to include('table-scroll-shell')
+      expect(response.body).to include('venue-requests-table')
     end
 
     it 'denies student access' do
@@ -99,6 +101,20 @@ RSpec.describe 'Venue Requests', type: :request do
       expect(response.body).to include('Venue Request Details')
       expect(response.body).to include('Duplicate')
       expect(response.body).to include(venue_requests_path(status: 'all'))
+    end
+
+    it 'uses distinct approve/reject action sections for pending requests' do
+      pending_request = create(:venue_request, requester: staff_user, tenant: tenant, status: :pending)
+      log_in_as(admin_user)
+
+      get venue_request_path(pending_request), params: { status: 'pending' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('venue-request-review-grid')
+      expect(response.body).to include('btn btn-success btn-sm venue-request-review-button')
+      expect(response.body).to include('btn btn-danger btn-sm venue-request-review-button')
+      expect(response.body).to include('Approve request')
+      expect(response.body).to include('Reject request')
     end
 
     it 'blocks other staff from viewing the request' do

--- a/spec/requests/venues_spec.rb
+++ b/spec/requests/venues_spec.rb
@@ -64,6 +64,23 @@ RSpec.describe "/venues", type: :request do
       expect(response.body.index("Alpha Room")).to be < response.body.index("Zulu Room")
     end
 
+    it "keeps the actions column consistent between admin and staff views" do
+      create(:venue, name: "Long Venue Name For Layout Stability Check", tenant: science_tenant, department: science_tenant.name)
+
+      get venues_url
+      expect(response.body).to include("venues-table")
+      expect(response.body).to include("venues-col-actions")
+      expect(response.body).to include("venues-actions-group")
+
+      staff = create(:user, :staff, tenant: science_tenant)
+      log_in_as(staff)
+      get venues_url
+
+      expect(response.body).to include("venues-table")
+      expect(response.body).to include("venues-col-actions")
+      expect(response.body).to include("venues-actions-group")
+    end
+
     it "shows root staff a request-new-venue action instead of direct creation" do
       root_staff = create(:user, :root_account, tenant: new_asia_tenant)
       log_in_as(root_staff)

--- a/spec/views/dashboards/approvals.html.erb_spec.rb
+++ b/spec/views/dashboards/approvals.html.erb_spec.rb
@@ -30,6 +30,9 @@ RSpec.describe "dashboards/approvals", type: :view do
 
     assert_select "table#approvals-table.resource-grid-table"
     assert_select "table#approvals-table tbody tr", count: 2
+    assert_select "table#approvals-table td.approval-actions-cell", count: 2
+    assert_select "table#approvals-table .approval-action-stack", count: 2
+    assert_select "table#approvals-table .approval-reject-label", text: "Reason", count: 2
     expect(rendered).to include("Room 101")
     expect(rendered).to include("Pending")
   end

--- a/spec/views/dashboards/approvals.html.erb_spec.rb
+++ b/spec/views/dashboards/approvals.html.erb_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe "dashboards/approvals", type: :view do
     assert_select "table#approvals-table tbody tr", count: 2
     assert_select "table#approvals-table td.approval-actions-cell", count: 2
     assert_select "table#approvals-table .approval-action-stack", count: 2
-    assert_select "table#approvals-table .approval-reject-label", text: "Reason", count: 2
     expect(rendered).to include("Room 101")
     expect(rendered).to include("Pending")
   end


### PR DESCRIPTION
## Summary
- make the venue requests list horizontally scrollable with less cramped columns so the right-most View action stays visible
- redesign pending venue-request review actions into clearly separated approve/reject sections with stronger visual contrast
- reorganize the student booking page so date + start/end selectors are grouped together, and make the timetable time column wider/non-wrapping
- remove duplicated timetable date display and use a single clear time-slot header
- update request specs and booking timetable cucumber steps to cover the new UI structure

## Verification
- bin/rubocop
- bundle exec rspec
- bundle exec cucumber