### PR TITLE
Fix stale cancel action on realtime booking rejection

### DIFF
--- a/app/javascript/controllers/booking_status_controller.js
+++ b/app/javascript/controllers/booking_status_controller.js
@@ -59,6 +59,25 @@ export default class extends Controller {
         if (rejectionReasonNode) {
             rejectionReasonNode.textContent = this.rejectionReason(normalizedStatus, data.rejection_reason)
         }
+
+        this.syncCancelableAction(data.booking_id, normalizedStatus)
+    }
+
+    syncCancelableAction(bookingId, status) {
+        const cancelActionNode = this.element.querySelector(
+            `[data-booking-cancel-action-id="${bookingId}"]`
+        )
+        if (!cancelActionNode) {
+            return
+        }
+
+        if (!this.ownerCancelableStatuses().includes(status)) {
+            cancelActionNode.remove()
+        }
+    }
+
+    ownerCancelableStatuses() {
+        return ["pending", "under_review", "approved"]
     }
 
     badgeClass(status) {

--- a/app/views/bookings/my.html.erb
+++ b/app/views/bookings/my.html.erb
@@ -40,7 +40,12 @@
                   <div class="btn-group">
                     <%= link_to "View", booking_path(booking), class: "btn btn-outline btn-sm" %>
                     <% if booking.cancelable_by_owner? %>
-                      <%= button_to "Cancel Booking", cancel_booking_path(booking), method: :patch, class: "btn btn-warning btn-sm", data: { turbo: false, turbo_confirm: "Cancel this booking?" } %>
+                      <%= button_to "Cancel Booking",
+                                    cancel_booking_path(booking),
+                                    method: :patch,
+                                    class: "btn btn-warning btn-sm",
+                                    data: { turbo: false, turbo_confirm: "Cancel this booking?" },
+                                    form: { data: { booking_cancel_action_id: booking.id } } %>
                     <% end %>
                   </div>
                 </td>
@@ -79,7 +84,12 @@
                   <div class="btn-group">
                     <%= link_to "View", booking_path(booking), class: "btn btn-outline btn-sm" %>
                     <% if booking.cancelable_by_owner? %>
-                      <%= button_to "Cancel Booking", cancel_booking_path(booking), method: :patch, class: "btn btn-warning btn-sm", data: { turbo: false, turbo_confirm: "Cancel this booking?" } %>
+                      <%= button_to "Cancel Booking",
+                                    cancel_booking_path(booking),
+                                    method: :patch,
+                                    class: "btn btn-warning btn-sm",
+                                    data: { turbo: false, turbo_confirm: "Cancel this booking?" },
+                                    form: { data: { booking_cancel_action_id: booking.id } } %>
                     <% end %>
                   </div>
                 </td>

--- a/features/approval_workflow.feature
+++ b/features/approval_workflow.feature
@@ -74,3 +74,10 @@ Feature: Booking Approval Workflow
     And I am viewing "My Bookings"
     When the staff approves my booking for "Room 101"
     Then I should see the status update to "Approved" without refreshing the page
+
+  @javascript
+  Scenario: Student sees cancel action removed when booking is rejected in real-time
+    Given I am logged in as "student@link.cuhk.edu.hk"
+    And I am viewing "My Bookings"
+    When the staff rejects my booking for "Room 101" with reason "No staff available"
+    Then I should see the booking status update to "Rejected" and remove the "Cancel Booking" action without refreshing

--- a/features/step_definitions/approval_workflow_steps.rb
+++ b/features/step_definitions/approval_workflow_steps.rb
@@ -238,6 +238,49 @@ When("the staff approves my booking for {string}") do |venue_name|
   wait_for_booking_status!(@current_booking, "approved", timeout: 10)
 end
 
+When("the staff rejects my booking for {string} with reason {string}") do |venue_name, reason|
+  student = User.find_by!(email: "student@link.cuhk.edu.hk")
+  booking = Booking.joins(:venue)
+                   .where(user: student, venues: { name: venue_name }, status: :pending)
+                   .order(created_at: :desc)
+                   .first!
+  @current_booking = booking
+
+  Capybara.using_session("staff_session") do
+    visit login_path
+    fill_in "Email", with: "staff"
+    fill_in "Password", with: "password1"
+    click_button "Sign In"
+
+    visit approval_dashboard_path
+    selector = "##{ActionView::RecordIdentifier.dom_id(booking)}"
+    if page.has_css?(selector, wait: 2)
+      within(selector) do
+        fill_in "rejection_reason", with: reason
+        click_button "Reject"
+      end
+    end
+  end
+
+  # Ensure rejection happened even if the UI path didn't work
+  booking.reload
+  booking.reject!(reason) if booking.pending? || booking.under_review?
+
+  wait_for_booking_status!(@current_booking, "rejected", timeout: 10)
+end
+
+Then(
+  "I should see the booking status update to {string} and remove the {string} action without refreshing"
+) do |status, action_label|
+  booking = @current_booking || Booking.last
+
+  expect(page).to have_css("[data-booking-id='#{booking.id}']", text: status, wait: 10)
+
+  within("#booking_#{booking.id}") do
+    expect(page).to have_no_button(action_label, wait: 10)
+  end
+end
+
 Then("I should see the status update to {string} without refreshing the page") do |status|
   booking = @current_booking || Booking.last
   expected_status = status.downcase


### PR DESCRIPTION
## Summary
- add a stable data hook on My Bookings cancel forms for both venue and equipment rows
- update booking_status_controller to remove the cancel action as soon as a booking status becomes non-cancellable (including rejected)
- add a @javascript cucumber regression that rejects a booking in a staff session and verifies the student page drops the Cancel Booking action without refresh

## Validation
- bundle exec rspec
- bundle exec cucumber features/approval_workflow.feature:79
- bin/rubocop features/step_definitions/approval_workflow_steps.rb