### PR TITLE
Prevent earlier end dates in equipment borrow form

### DIFF
--- a/app/javascript/controllers/booking_date_range_controller.js
+++ b/app/javascript/controllers/booking_date_range_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["startDate", "endDate"]
+  static values = { minimumDate: String }
+
+  connect() {
+    this.syncEndDateMinimum()
+  }
+
+  syncEndDateMinimum() {
+    const minimumDate = this.startDateTarget.value || this.minimumDateValue || this.endDateTarget.min
+
+    if (minimumDate) {
+      this.endDateTarget.min = minimumDate
+    }
+
+    if (this.endDateTarget.value && minimumDate && this.endDateTarget.value < minimumDate) {
+      this.endDateTarget.value = minimumDate
+    }
+  }
+}

--- a/app/views/equipments/borrow_form.html.erb
+++ b/app/views/equipments/borrow_form.html.erb
@@ -6,7 +6,11 @@
     <span class="badge badge-approved"><%= @equipment.available_quantity %> / <%= @equipment.quantity %> available</span>
   </div>
   <div class="card-body">
-    <%= form_with model: @booking, url: borrow_equipment_path(@equipment), data: { turbo: false } do |f| %>
+    <%= form_with model: @booking, url: borrow_equipment_path(@equipment), data: {
+      turbo: false,
+      controller: "booking-date-range",
+      booking_date_range_minimum_date_value: booking_date_minimum
+    } do |f| %>
       <% if @booking.errors.any? %>
         <div class="alert mb-2">
           <ul style="margin:0; padding-left:1.2rem;">
@@ -24,12 +28,15 @@
 
       <div class="form-group">
         <%= f.label :start_date, "Start date" %>
-        <%= f.date_field :start_date, required: true, min: booking_date_minimum %>
+        <%= f.date_field :start_date, required: true, min: booking_date_minimum, data: {
+          booking_date_range_target: "startDate",
+          action: "input->booking-date-range#syncEndDateMinimum change->booking-date-range#syncEndDateMinimum"
+        } %>
       </div>
 
       <div class="form-group">
         <%= f.label :end_date, "End date" %>
-        <%= f.date_field :end_date, required: true, min: booking_date_minimum %>
+        <%= f.date_field :end_date, required: true, min: booking_date_minimum, data: { booking_date_range_target: "endDate" } %>
       </div>
 
       <%= f.submit "Borrow", class: "btn btn-primary" %>

--- a/spec/views/equipments/borrow_form.html.erb_spec.rb
+++ b/spec/views/equipments/borrow_form.html.erb_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe 'equipments/borrow_form', type: :view do
     assign(:booking, EquipmentBooking.new(equipment: equipment))
   end
 
-  it 'renders borrow form with minimum dates' do
+  it 'renders borrow form with date constraints' do
     render
 
     expected_min = 5.days.from_now.to_date.to_s
 
-    assert_select 'form' do
-      assert_select 'input[name=?][min=?]', 'booking[start_date]', expected_min
-      assert_select 'input[name=?][min=?]', 'booking[end_date]', expected_min
+    assert_select "form[data-controller='booking-date-range']" do
+      assert_select "input[name='booking[start_date]'][min='#{expected_min}'][data-booking-date-range-target='startDate'][data-action*='booking-date-range#syncEndDateMinimum']"
+      assert_select "input[name='booking[end_date]'][min='#{expected_min}'][data-booking-date-range-target='endDate']"
     end
   end
 end


### PR DESCRIPTION
## Summary
- add a Stimulus controller to keep booking end_date constrained to the selected booking start_date
- wire the student equipment borrow form to the new controller and sync the end-date minimum on load and when start date changes
- update the borrow form view spec to cover the new controller bindings and date field constraints

## Testing
- bin/rubocop
- bundle exec rspec
- bundle exec cucumber