### PR TITLE
Protect root staff deletion and reconcile bootstrap seed accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The seed run also prints a verification summary and fails fast if the expected t
 | S.H. Ho College | `staff_root_shho@link.cuhk.edu.hk` | `Password1!` |
 | CW Chu College | `staff_root_cwchu@link.cuhk.edu.hk` | `Password1!` |
 | Wu Yee Sun College | `staff_root_wuyeesun@link.cuhk.edu.hk` | `Password1!` |
-| Lee Woo Sing College | `staff_root_leewoosin@link.cuhk.edu.hk` | `Password1!` |
+| Lee Woo Sing College | `staff_root_leewoosing@link.cuhk.edu.hk` | `Password1!` |
 
 Student accounts can be created via the signup page (students select their college during registration).
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -14,7 +14,7 @@ class Admin::UsersController < ApplicationController
 
     @user.destroy!
     redirect_to admin_users_path, notice: "Account deleted: #{@user.email}"
-  rescue ActiveRecord::RecordNotDestroyed, ActiveRecord::InvalidForeignKey
+  rescue ActiveRecord::DeleteRestrictionError, ActiveRecord::RecordNotDestroyed, ActiveRecord::InvalidForeignKey
     redirect_to admin_users_path, alert: "Account could not be deleted because dependent records still reference it."
   end
 
@@ -45,6 +45,7 @@ class Admin::UsersController < ApplicationController
 
   def account_deletion_blocked_message(user)
     return "You cannot delete your own admin account." if user == current_user
+    return "Root staff accounts are protected and cannot be deleted." if user.root_staff_account?
     return "You cannot delete the last admin account." if user.admin? && User.admin.count <= 1
 
     "Account could not be deleted."

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,7 @@ class User < ApplicationRecord
 
   def deletable_by_admin?(acting_admin)
     return false if acting_admin == self
+    return false if root_staff_account?
     return false if admin? && User.admin.count <= 1
 
     true

--- a/app/services/bootstrap_account_reconciler.rb
+++ b/app/services/bootstrap_account_reconciler.rb
@@ -1,0 +1,88 @@
+class BootstrapAccountReconciler
+  ADMIN_EMAIL = "admin@link.cuhk.edu.hk".freeze
+
+  def initialize(tenants:, root_staff_emails:, bootstrap_password:, reset_passwords:, reconcile_obsolete_accounts:)
+    @tenants = tenants
+    @root_staff_emails = root_staff_emails
+    @bootstrap_password = bootstrap_password
+    @reset_passwords = reset_passwords
+    @reconcile_obsolete_accounts = reconcile_obsolete_accounts
+  end
+
+  def call
+    admin = ensure_admin_account!
+    root_staff_users = ensure_root_staff_accounts!
+
+    reconcile_obsolete_accounts!(admin:, root_staff_users:) if @reconcile_obsolete_accounts
+
+    { admin:, root_staff_users: }
+  end
+
+  private
+
+  attr_reader :tenants, :root_staff_emails, :bootstrap_password
+
+  def ensure_admin_account!
+    admin = User.find_or_initialize_by(email: ADMIN_EMAIL)
+    admin.role = :admin
+    admin.is_root_account = false
+    admin.tenant = tenants.fetch("University")
+    assign_password_if_needed(admin)
+    admin.save!
+    admin
+  end
+
+  def ensure_root_staff_accounts!
+    root_staff_emails.each_with_object({}) do |(college_name, email), memo|
+      user = User.find_or_initialize_by(email: email)
+      user.role = :staff
+      user.is_root_account = true
+      user.tenant = tenants.fetch(college_name)
+      assign_password_if_needed(user)
+      user.save!
+      memo[college_name] = user
+    end
+  end
+
+  def assign_password_if_needed(user)
+    return unless @reset_passwords || user.new_record? || user.password_digest.blank?
+
+    user.password = bootstrap_password
+    user.password_confirmation = bootstrap_password
+  end
+
+  def reconcile_obsolete_accounts!(admin:, root_staff_users:)
+    root_staff_by_tenant_id = root_staff_users.values.index_by(&:tenant_id)
+
+    stale_bootstrap_accounts(root_staff_users).each do |stale_user|
+      replacement_user = replacement_for(stale_user, admin:, root_staff_by_tenant_id:)
+      reassign_dependencies!(from_user: stale_user, to_user: replacement_user) if replacement_user
+      stale_user.destroy!
+    end
+  end
+
+  def stale_bootstrap_accounts(root_staff_users)
+    stale_admins = User.admin.where.not(email: ADMIN_EMAIL)
+    canonical_root_emails = root_staff_users.values.map(&:email)
+    stale_root_staff = User.staff.root_accounts.where.not(email: canonical_root_emails)
+
+    (stale_admins + stale_root_staff).uniq
+  end
+
+  def replacement_for(stale_user, admin:, root_staff_by_tenant_id:)
+    return admin if stale_user.admin?
+    return root_staff_by_tenant_id[stale_user.tenant_id] if stale_user.root_staff_account?
+
+    nil
+  end
+
+  def reassign_dependencies!(from_user:, to_user:)
+    return if from_user.id == to_user.id
+
+    Booking.where(user_id: from_user.id).update_all(user_id: to_user.id)
+    ApiKey.where(user_id: from_user.id).update_all(user_id: to_user.id)
+    ApprovalStep.where(actor_id: from_user.id).update_all(actor_id: to_user.id)
+    VenueRequest.where(requester_id: from_user.id).update_all(requester_id: to_user.id)
+    VenueRequest.where(reviewed_by_id: from_user.id).update_all(reviewed_by_id: to_user.id)
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,7 +23,7 @@ root_staff_emails = {
   "S.H. Ho College" => "staff_root_shho@link.cuhk.edu.hk",
   "CW Chu College" => "staff_root_cwchu@link.cuhk.edu.hk",
   "Wu Yee Sun College" => "staff_root_wuyeesun@link.cuhk.edu.hk",
-  "Lee Woo Sing College" => "staff_root_leewoosin@link.cuhk.edu.hk"
+  "Lee Woo Sing College" => "staff_root_leewoosing@link.cuhk.edu.hk"
 }
 
 demo_student_emails = {
@@ -238,7 +238,7 @@ else
 end
 
 if Rails.env.production? && reset_bootstrap_accounts_once
-  puts "RESET_BOOTSTRAP_ACCOUNTS_ONCE is enabled; bootstrap account passwords will be reset in this seed run."
+  puts "RESET_BOOTSTRAP_ACCOUNTS_ONCE is enabled; canonical bootstrap admin/root accounts will be reset and reconciled in this seed run."
 end
 
 puts "Ensuring tenants..."
@@ -275,34 +275,17 @@ equipments.each do |equipment_attrs|
   end
 end
 
-puts "Ensuring admin account..."
-admin = User.find_or_initialize_by(email: "admin@link.cuhk.edu.hk")
-admin.role = :admin
-admin.tenant = tenants["University"]
+puts "Ensuring admin and root staff accounts..."
+bootstrap_accounts = BootstrapAccountReconciler.new(
+  tenants: tenants,
+  root_staff_emails: root_staff_emails,
+  bootstrap_password: bootstrap_password,
+  reset_passwords: reset_bootstrap_accounts_once,
+  reconcile_obsolete_accounts: Rails.env.production? && reset_bootstrap_accounts_once
+).call
 
-if reset_bootstrap_accounts_once || admin.new_record? || admin.password_digest.blank?
-  admin.password = bootstrap_password
-  admin.password_confirmation = bootstrap_password
-end
-
-admin.save!
-
-puts "Ensuring root staff accounts..."
-root_staff_users = {}
-root_staff_emails.each do |college_name, email|
-  user = User.find_or_initialize_by(email: email)
-  user.role = :staff
-  user.is_root_account = true
-  user.tenant = tenants.fetch(college_name)
-
-  if reset_bootstrap_accounts_once || user.new_record? || user.password_digest.blank?
-    user.password = bootstrap_password
-    user.password_confirmation = bootstrap_password
-  end
-
-  user.save!
-  root_staff_users[college_name] = user
-end
+admin = bootstrap_accounts.fetch(:admin)
+root_staff_users = bootstrap_accounts.fetch(:root_staff_users)
 
 puts "Ensuring demo student accounts..."
 demo_students = {}

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -96,6 +96,22 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#deletable_by_admin?' do
+    let(:acting_admin) { create(:user, :admin) }
+
+    it 'returns false for root staff accounts' do
+      root_staff = create(:user, :root_account, tenant: create(:tenant))
+
+      expect(root_staff.deletable_by_admin?(acting_admin)).to be(false)
+    end
+
+    it 'returns true for regular staff accounts' do
+      staff = create(:user, :staff, tenant: create(:tenant))
+
+      expect(staff.deletable_by_admin?(acting_admin)).to be(true)
+    end
+  end
+
   describe 'active session lock' do
     let(:user) { create(:user, :admin) }
 

--- a/spec/requests/admin_users_spec.rb
+++ b/spec/requests/admin_users_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'nokogiri'
 
 RSpec.describe 'Admin user management', type: :request do
   let!(:tenant) { create(:tenant, name: 'New Asia College') }
@@ -27,6 +28,19 @@ RSpec.describe 'Admin user management', type: :request do
       expect(response).to redirect_to(root_path)
       expect(flash[:alert]).to eq('You are not authorized to perform this action.')
     end
+
+    it 'shows root staff accounts as protected without delete action' do
+      log_in_as(admin)
+
+      get admin_users_path
+
+      document = Nokogiri::HTML(response.body)
+      root_row = document.css('tr').find { |row| row.text.include?(root_staff.email) }
+
+      expect(root_row).not_to be_nil
+      expect(root_row.text).to include('Protected')
+      expect(root_row.at_css("form[action='#{admin_user_path(root_staff)}']")).to be_nil
+    end
   end
 
   describe 'DELETE /admin/users/:id' do
@@ -50,6 +64,17 @@ RSpec.describe 'Admin user management', type: :request do
 
       expect(response).to redirect_to(admin_users_path)
       expect(flash[:alert]).to eq('You cannot delete your own admin account.')
+    end
+
+    it 'blocks deleting root staff accounts' do
+      log_in_as(admin)
+
+      expect {
+        delete admin_user_path(root_staff)
+      }.not_to change(User, :count)
+
+      expect(response).to redirect_to(admin_users_path)
+      expect(flash[:alert]).to eq('Root staff accounts are protected and cannot be deleted.')
     end
   end
 

--- a/spec/services/bootstrap_account_reconciler_spec.rb
+++ b/spec/services/bootstrap_account_reconciler_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+
+RSpec.describe BootstrapAccountReconciler do
+  let!(:university_tenant) { create(:tenant, name: "University", slug: "university") }
+  let!(:new_asia_tenant) { create(:tenant, name: "New Asia College", slug: "new-asia-college") }
+  let!(:lee_woo_sing_tenant) { create(:tenant, name: "Lee Woo Sing College", slug: "lee-woo-sing-college") }
+
+  let(:tenants) do
+    {
+      "University" => university_tenant,
+      "New Asia College" => new_asia_tenant,
+      "Lee Woo Sing College" => lee_woo_sing_tenant
+    }
+  end
+
+  let(:root_staff_emails) do
+    {
+      "New Asia College" => "staff_root_newasia@link.cuhk.edu.hk",
+      "Lee Woo Sing College" => "staff_root_leewoosing@link.cuhk.edu.hk"
+    }
+  end
+
+  let(:bootstrap_password) { "BootstrapPass1!" }
+
+  describe "#call" do
+    it "reconciles stale bootstrap admin/root accounts and resets canonical credentials" do
+      canonical_admin = create(
+        :user,
+        :admin,
+        tenant: university_tenant,
+        email: "admin@link.cuhk.edu.hk",
+        password: "LegacyPass1!",
+        password_confirmation: "LegacyPass1!"
+      )
+      stale_admin = create(:user, :admin, tenant: university_tenant, email: "admin_legacy@link.cuhk.edu.hk")
+
+      canonical_new_asia_root = create(
+        :user,
+        :root_account,
+        tenant: new_asia_tenant,
+        email: "staff_root_newasia@link.cuhk.edu.hk",
+        password: "LegacyPass1!",
+        password_confirmation: "LegacyPass1!"
+      )
+      stale_lee_root = create(
+        :user,
+        :root_account,
+        tenant: lee_woo_sing_tenant,
+        email: "staff_root_leewoosin@link.cuhk.edu.hk"
+      )
+
+      lee_venue = create(:venue, tenant: lee_woo_sing_tenant, department: lee_woo_sing_tenant.name)
+      stale_booking = create(:booking, user: stale_lee_root, venue: lee_venue)
+      stale_api_key = create(:api_key, user: stale_lee_root)
+      stale_request = create(:venue_request, requester: stale_lee_root, tenant: lee_woo_sing_tenant)
+      stale_root_step = create(:approval_step, actor: stale_lee_root)
+
+      requester = create(:user, :staff, tenant: new_asia_tenant)
+      reviewed_request = create(
+        :venue_request,
+        requester: requester,
+        tenant: new_asia_tenant,
+        status: :approved,
+        reviewed_by: stale_admin,
+        reviewed_at: Time.current
+      )
+      stale_admin_step = create(:approval_step, actor: stale_admin)
+
+      result = described_class.new(
+        tenants: tenants,
+        root_staff_emails: root_staff_emails,
+        bootstrap_password: bootstrap_password,
+        reset_passwords: true,
+        reconcile_obsolete_accounts: true
+      ).call
+
+      canonical_lee_root = User.find_by!(email: "staff_root_leewoosing@link.cuhk.edu.hk")
+
+      expect(result[:admin]).to eq(canonical_admin)
+      expect(result[:root_staff_users].keys).to contain_exactly("New Asia College", "Lee Woo Sing College")
+      expect(result[:root_staff_users]["Lee Woo Sing College"]).to eq(canonical_lee_root)
+
+      expect(canonical_admin.reload.authenticate(bootstrap_password)).to eq(canonical_admin)
+      expect(canonical_new_asia_root.reload.authenticate(bootstrap_password)).to eq(canonical_new_asia_root)
+      expect(canonical_lee_root.authenticate(bootstrap_password)).to eq(canonical_lee_root)
+
+      expect(User.exists?(stale_admin.id)).to be(false)
+      expect(User.exists?(stale_lee_root.id)).to be(false)
+
+      expect(stale_booking.reload.user_id).to eq(canonical_lee_root.id)
+      expect(stale_api_key.reload.user_id).to eq(canonical_lee_root.id)
+      expect(stale_request.reload.requester_id).to eq(canonical_lee_root.id)
+      expect(stale_root_step.reload.actor_id).to eq(canonical_lee_root.id)
+      expect(reviewed_request.reload.reviewed_by_id).to eq(canonical_admin.id)
+      expect(stale_admin_step.reload.actor_id).to eq(canonical_admin.id)
+    end
+
+    it "does not reset existing canonical passwords when reset is disabled" do
+      admin = create(
+        :user,
+        :admin,
+        tenant: university_tenant,
+        email: "admin@link.cuhk.edu.hk",
+        password: "KeepCurrent1!",
+        password_confirmation: "KeepCurrent1!"
+      )
+      new_asia_root = create(
+        :user,
+        :root_account,
+        tenant: new_asia_tenant,
+        email: "staff_root_newasia@link.cuhk.edu.hk",
+        password: "KeepCurrent1!",
+        password_confirmation: "KeepCurrent1!"
+      )
+
+      described_class.new(
+        tenants: tenants,
+        root_staff_emails: root_staff_emails,
+        bootstrap_password: bootstrap_password,
+        reset_passwords: false,
+        reconcile_obsolete_accounts: false
+      ).call
+
+      expect(admin.reload.authenticate("KeepCurrent1!")).to eq(admin)
+      expect(new_asia_root.reload.authenticate("KeepCurrent1!")).to eq(new_asia_root)
+      expect(admin.authenticate(bootstrap_password)).to be_falsey
+      expect(new_asia_root.authenticate(bootstrap_password)).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
Summary
- Prevent root staff account deletion from the admin account manager UI and backend policy checks.
- Add regression tests for root staff delete protection in admin user management.
- Introduce BootstrapAccountReconciler for bootstrap admin and root staff seeding.
- Fix Lee Woo Sing root staff seed email typo to staff_root_leewoosing@link.cuhk.edu.hk.
- When RESET_BOOTSTRAP_ACCOUNTS_ONCE is enabled in production, reconcile bootstrap accounts by resetting canonical passwords, creating missing canonical accounts, reassigning dependent records from obsolete bootstrap accounts, and removing obsolete bootstrap admin and root staff accounts not in seed mapping.

Validation
- RAILS_ENV=test bin/rails db:drop db:create db:schema:load
- bin/rubocop
- bin/brakeman --no-pager
- bin/bundler-audit
- bin/importmap audit
- bundle exec rspec
- bundle exec cucumber --publish-quiet

Deploy note
- Keep RESET_BOOTSTRAP_ACCOUNTS_ONCE=true for one deploy to reconcile and reset bootstrap accounts, then set it back to false to avoid repeated password resets.