### PR TITLE
Harden password policy for registration and admin resets

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -24,7 +24,7 @@ class Admin::UsersController < ApplicationController
       return
     end
 
-    generated_password = SecureRandom.base58(16)
+    generated_password = User.generate_compliant_password(length: 16)
     @user.password = generated_password
     @user.password_confirmation = generated_password
     @user.save!

--- a/app/javascript/controllers/registration_form_controller.js
+++ b/app/javascript/controllers/registration_form_controller.js
@@ -1,16 +1,19 @@
 import { Controller } from "@hotwired/stimulus"
 
 const PASSWORD_LENGTH = 14
+const MIN_PASSWORD_LENGTH = 10
 const UPPERCASE = "ABCDEFGHJKLMNPQRSTUVWXYZ"
 const LOWERCASE = "abcdefghijkmnopqrstuvwxyz"
 const NUMBERS = "23456789"
 const SYMBOLS = "!@#$%^&*()-_=+[]{}?"
+const PASSWORD_COMPLEXITY_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).+$/
 
 export default class extends Controller {
   static targets = [
     "password",
     "passwordConfirmation",
     "minLengthRule",
+    "complexityRule",
     "confirmationRule",
     "rulesSummary",
     "generatedPanel",
@@ -30,13 +33,15 @@ export default class extends Controller {
     const password = this.passwordTarget.value.toString()
     const confirmation = this.passwordConfirmationTarget.value.toString()
 
-    const hasMinimumLength = password.length >= 8
+    const hasMinimumLength = password.length >= MIN_PASSWORD_LENGTH
+    const meetsComplexity = PASSWORD_COMPLEXITY_REGEX.test(password)
     const confirmationMatches = confirmation.length > 0 && password === confirmation
 
     this.applyRuleState(this.minLengthRuleTarget, hasMinimumLength)
+    this.applyRuleState(this.complexityRuleTarget, meetsComplexity)
     this.applyRuleState(this.confirmationRuleTarget, confirmationMatches)
 
-    this.applySummaryState(hasMinimumLength && confirmationMatches)
+    this.applySummaryState(hasMinimumLength && meetsComplexity && confirmationMatches)
   }
 
   generatePassword(event) {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,13 @@ class User < ApplicationRecord
   DEFAULT_ACTIVE_SESSION_LOCK_TOUCH_INTERVAL = 5.minutes
   CUHK_EMAIL_DOMAIN = "link.cuhk.edu.hk"
   CUHK_EMAIL_REGEX = /\A[a-zA-Z0-9._%+-]+@#{Regexp.escape(CUHK_EMAIL_DOMAIN)}\z/i
+  PASSWORD_MIN_LENGTH = 10
+  PASSWORD_COMPLEXITY_REGEX = /\A(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).+\z/
+  PASSWORD_COMPLEXITY_MESSAGE = "must include at least one uppercase letter, one lowercase letter, one number, and one symbol"
+  PASSWORD_UPPERCASE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ"
+  PASSWORD_LOWERCASE_CHARS = "abcdefghijkmnopqrstuvwxyz"
+  PASSWORD_DIGIT_CHARS = "23456789"
+  PASSWORD_SYMBOL_CHARS = "!@#$%^&*()-_=+[]{}?"
 
   def root_account?
     is_root_account
@@ -108,16 +115,63 @@ class User < ApplicationRecord
     "#{local_part}@#{CUHK_EMAIL_DOMAIN}"
   end
 
+  def self.generate_compliant_password(length: 14)
+    target_length = [length.to_i, PASSWORD_MIN_LENGTH].max
+    required_sets = [
+      PASSWORD_UPPERCASE_CHARS,
+      PASSWORD_LOWERCASE_CHARS,
+      PASSWORD_DIGIT_CHARS,
+      PASSWORD_SYMBOL_CHARS
+    ]
+
+    password_characters = required_sets.map { |set| random_password_character(set) }
+    all_characters = required_sets.join
+
+    while password_characters.length < target_length
+      password_characters << random_password_character(all_characters)
+    end
+
+    secure_shuffle(password_characters).join
+  end
+
   validates :email, presence: true,
                     uniqueness: { case_sensitive: false },
                     format: { with: CUHK_EMAIL_REGEX,
                               message: "must be a valid @link.cuhk.edu.hk address" }
-  validates :password, length: { minimum: 8 }, if: -> { new_record? || password.present? }
+  validates :password, length: { minimum: PASSWORD_MIN_LENGTH }, if: :password_validation_required?
+  validate :password_must_meet_complexity_requirements, if: :password_validation_required?
   validates :password_confirmation, presence: true, if: :new_record?
 
   normalizes :email, with: ->(email) { email.strip.downcase }
 
   private
+
+  def self.random_password_character(characters)
+    characters[SecureRandom.random_number(characters.length)]
+  end
+  private_class_method :random_password_character
+
+  def self.secure_shuffle(values)
+    shuffled_values = values.dup
+
+    (shuffled_values.length - 1).downto(1) do |index|
+      swap_index = SecureRandom.random_number(index + 1)
+      shuffled_values[index], shuffled_values[swap_index] = shuffled_values[swap_index], shuffled_values[index]
+    end
+
+    shuffled_values
+  end
+  private_class_method :secure_shuffle
+
+  def password_validation_required?
+    new_record? || password.present?
+  end
+
+  def password_must_meet_complexity_requirements
+    return if password.to_s.match?(PASSWORD_COMPLEXITY_REGEX)
+
+    errors.add(:password, PASSWORD_COMPLEXITY_MESSAGE)
+  end
 
   def clear_active_session_lock!
     update!(active_session_token: nil, active_session_token_issued_at: nil)

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -83,7 +83,10 @@
         </p>
         <ul class="password-rules">
           <li class="password-rule pending" data-registration-form-target="minLengthRule">
-            At least 8 characters
+            At least 10 characters
+          </li>
+          <li class="password-rule pending" data-registration-form-target="complexityRule">
+            Includes uppercase, lowercase, number, and symbol
           </li>
           <li class="password-rule pending" data-registration-form-target="confirmationRule">
             Matches confirmation password

--- a/features/approval_workflow.feature
+++ b/features/approval_workflow.feature
@@ -6,8 +6,8 @@ Feature: Booking Approval Workflow
   Background:
     Given the following users exist:
       | email                 | password  | role    |
-      | student@link.cuhk.edu.hk   | password1 | student |
-      | staff@link.cuhk.edu.hk | password1 | staff   |
+      | student@link.cuhk.edu.hk   | Password1! | student |
+      | staff@link.cuhk.edu.hk | Password1! | staff   |
     And the following venues exist:
       | name     | department      |
       | Room 101 | Science Faculty |

--- a/features/resend_email.feature
+++ b/features/resend_email.feature
@@ -6,8 +6,8 @@ Feature: Resend Email Notifications (External API)
   Background:
     Given the following users exist:
       | email                        | password  | role           |
-      | student@link.cuhk.edu.hk     | password1 | student |
-      | staff@link.cuhk.edu.hk       | password1 | staff          |
+      | student@link.cuhk.edu.hk     | Password1! | student |
+      | staff@link.cuhk.edu.hk       | Password1! | staff          |
     And the following venues exist:
       | name     | department      |
       | Room 201 | Science Faculty |

--- a/features/step_definitions/approval_workflow_steps.rb
+++ b/features/step_definitions/approval_workflow_steps.rb
@@ -219,7 +219,7 @@ When("the staff approves my booking for {string}") do |venue_name|
   Capybara.using_session("staff_session") do
     visit login_path
     fill_in "Email", with: "staff"
-    fill_in "Password", with: "password1"
+    fill_in "Password", with: "Password1!"
     click_button "Sign In"
 
     visit approval_dashboard_path
@@ -249,7 +249,7 @@ When("the staff rejects my booking for {string} with reason {string}") do |venue
   Capybara.using_session("staff_session") do
     visit login_path
     fill_in "Email", with: "staff"
-    fill_in "Password", with: "password1"
+    fill_in "Password", with: "Password1!"
     click_button "Sign In"
 
     visit approval_dashboard_path
@@ -339,7 +339,7 @@ end
 
 def sign_in_for_cucumber!(email)
   user = User.find_by!(email: email)
-  password = ["password", "password1", "Password1!"].find { |value| user.authenticate(value) }
+  password = ["Password1!", "password1", "password"].find { |value| user.authenticate(value) }
   raise "No valid password found for #{email}" unless password
 
   user.update!(active_session_token: nil)

--- a/features/step_definitions/venue_booking_steps.rb
+++ b/features/step_definitions/venue_booking_steps.rb
@@ -14,7 +14,7 @@ end
 Given('I am logged in as {string}') do |email|
   user = User.find_by!(email: email)
   user.update!(active_session_token: nil)
-  password = ["password", "password1", "Password1!"].find { |value| user.authenticate(value) }
+  password = ["Password1!", "password1", "password"].find { |value| user.authenticate(value) }
   raise "No valid password found for #{email}" unless password
 
   visit login_path

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,15 +32,32 @@ RSpec.describe User, type: :model do
       expect(user).not_to be_valid
     end
 
-    it 'requires a password of at least 8 characters' do
-      user = build(:user, password: 'short', password_confirmation: 'short')
+    it 'requires a password of at least 10 characters' do
+      user = build(:user, password: 'Short1!', password_confirmation: 'Short1!')
       expect(user).not_to be_valid
-      expect(user.errors[:password]).to include("is too short (minimum is 8 characters)")
+      expect(user.errors[:password]).to include("is too short (minimum is 10 characters)")
+    end
+
+    it 'requires password complexity with uppercase, lowercase, number, and symbol' do
+      user = build(:user, password: 'Password12', password_confirmation: 'Password12')
+      expect(user).not_to be_valid
+      expect(user.errors[:password]).to include(
+        "must include at least one uppercase letter, one lowercase letter, one number, and one symbol"
+      )
     end
 
     it 'normalizes email to lowercase' do
-      user = create(:user, email: ' Admin@link.CUHK.edu.hk ')
-      expect(user.email).to eq('admin@link.cuhk.edu.hk')
+      user = create(:user, email: ' MixedCaseUser@link.CUHK.edu.hk ')
+      expect(user.email).to eq('mixedcaseuser@link.cuhk.edu.hk')
+    end
+  end
+
+  describe '.generate_compliant_password' do
+    it 'returns a password that satisfies complexity requirements' do
+      password = described_class.generate_compliant_password(length: 12)
+
+      expect(password.length).to be >= 12
+      expect(password).to match(User::PASSWORD_COMPLEXITY_REGEX)
     end
   end
 

--- a/spec/requests/admin_users_spec.rb
+++ b/spec/requests/admin_users_spec.rb
@@ -93,6 +93,8 @@ RSpec.describe 'Admin user management', type: :request do
       payload_email = temp_password_payload["email"] || temp_password_payload[:email]
       expect(generated_password).to be_present
       expect(payload_email).to eq(root_staff.email)
+      expect(generated_password.length).to be >= User::PASSWORD_MIN_LENGTH
+      expect(generated_password).to match(User::PASSWORD_COMPLEXITY_REGEX)
 
       root_staff.reload
       expect(root_staff.authenticate(generated_password)).to eq(root_staff)

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe 'Registrations', type: :request do
       expect(response.body).not_to include('University')
       expect(response.body).to include('@link.cuhk.edu.hk')
       expect(response.body).to include('Generate strong password')
+      expect(response.body).to include('At least 10 characters')
+      expect(response.body).to include('Includes uppercase, lowercase, number, and symbol')
     end
   end
 
@@ -45,6 +47,22 @@ RSpec.describe 'Registrations', type: :request do
       verification = SignupVerificationCode.find_by(email: 'newstudent@link.cuhk.edu.hk')
       expect(verification).to be_present
       expect(ActionMailer::Base.deliveries.count).to eq(1)
+    end
+
+    it 'rejects weak passwords that do not meet complexity requirements' do
+      weak_password_params = valid_params.deep_merge(user: {
+        password: 'password12',
+        password_confirmation: 'password12'
+      })
+
+      expect {
+        post signup_path, params: weak_password_params
+      }.not_to change(User, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include(
+        'must include at least one uppercase letter, one lowercase letter, one number, and one symbol'
+      )
     end
 
     it 'still ignores role parameter in pending signup data' do


### PR DESCRIPTION
## Summary
- enforce stronger User password rules with a minimum length of 10 and required uppercase/lowercase/number/symbol composition
- add a compliant password generator in User and use it for admin root-staff temporary password resets
- align registration form password guidance and Stimulus rule checks with the new policy
- extend model/request specs to cover password complexity and compliant temporary password generation

## Validation
- bin/rubocop app/models/user.rb app/controllers/admin/users_controller.rb spec/models/user_spec.rb spec/requests/registrations_spec.rb spec/requests/admin_users_spec.rb
- bundle exec rspec
- bundle exec cucumber features/registration.feature